### PR TITLE
Switch from Stack to Cabal, also for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,25 @@
-language: haskell
-ghc: 7.6
+# Based on http://docs.haskellstack.org/en/stable/travis_ci/ and
+# http://docs.haskellstack.org/en/stable/GUIDE/#travis-with-caching
+#
+# Choose a lightweight base image; we provide our own build tools.
 sudo: false
+language: c
+addons: {apt: {packages: [libgmp-dev]}}
+
 cache:
   directories:
-  - ~/.cabal
-  - ~/.ghc
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
 
-# If this breaks, move to `stack install Agda-2.4.0.2` with needed stack setup.
-# See http://docs.haskellstack.org/en/stable/travis_ci/ and
-# http://docs.haskellstack.org/en/stable/GUIDE/#travis-with-caching for that.
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
 script:
-  - cabal install happy alex Agda --constraint 'alex >= 3.1.0 && < 3.2' --constraint 'happy >=1.19.3 && <2' --constraint 'Agda == 2.4.0.*'
+  - stack --no-terminal --install-ghc install Agda ilc
   - (mkdir -p ../stdlib; cd ../stdlib; curl -L https://github.com/agda/agda-stdlib/archive/v0.8.tar.gz|tar xz)
 
   - echo "AGDA_LIB=$(dirname $PWD)/stdlib/agda-stdlib-0.8/src" > agdaCheck.sh.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
   - $HOME/.ghc
   - $HOME/.cabal
   - $HOME/.stack
+  - $HOME/build/inc-lc/ilc-agda/.stack-work
 
 before_install:
 # Download and unpack the stack executable

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 script:
-  - stack --no-terminal --install-ghc install Agda ilc
+  - stack --no-terminal --install-ghc build Agda ilc
   - (mkdir -p ../stdlib; cd ../stdlib; curl -L https://github.com/agda/agda-stdlib/archive/v0.8.tar.gz|tar xz)
 
   - echo "AGDA_LIB=$(dirname $PWD)/stdlib/agda-stdlib-0.8/src" > agdaCheck.sh.conf

--- a/agdaCheck.sh
+++ b/agdaCheck.sh
@@ -4,4 +4,4 @@ cd "$(dirname "$0")"
 
 . agdaConfParse.sh.inc
 
-agda +RTS -s -RTS -i . -i ${AGDA_LIB} ${mainFile} "$@"
+stack exec --package Agda -- agda +RTS -s -RTS -i . -i ${AGDA_LIB} ${mainFile} "$@"

--- a/agdaConfParse.sh.inc
+++ b/agdaConfParse.sh.inc
@@ -41,41 +41,21 @@ showCdIfNeeded() {
 }
 
 generator=GenerateEverythingIlc
+stackCmdName="stack exec --package ilc GenerateEverythingIlc"
 
 if which "${generator}" > /dev/null; then
   logRunning "${generator}"
   ${generator} && { echo; logDone; } || { logFailed "${generator}"; exit 1; }
 else
   echo "\`${generator}\` is not installed (consider running \`cabal install\` to fix that)."
-  logRunning "cabal run"
+  logRunning "$stackCmdName"
   echo
 
-  cabal run
+  eval $stackCmdName
   ret=$?
   echo
   if [ "$ret" -ne 0 ]; then
-    logFailed "cabal run"
-    cat <<EOF
-Most likely, either:
-(1) some dependencies are missing, or
-(2) your cabal release is older than 1.18 and does not support \`cabal run\`.
-To fix missing dependencies (problem (1)), try running:
-
-EOF
-    showCdIfNeeded
-
-    cat <<EOF
-$ cabal install --only-dependencies -v --dry-run
-
-and if the installation plan in cabal's output looks fine, run:
-
-$ cabal install --only-dependencies
-$ ./$(basename "$0")
-
-If that fails, look at the output of cabal run to investigate the problem.
-
-To workaround an old cabal (problem (2)), either update cabal or just run \`cabal install\` (similarly to the above instructions).
-EOF
+    logFailed "$stackCmdName"
     exit 1
   else
     logDone

--- a/agdaConfParse.sh.inc
+++ b/agdaConfParse.sh.inc
@@ -24,42 +24,23 @@ fi
 # actually want the escape behavior.
 
 logDone() {
+  echo
   echo "Everything.agda regenerated."
   echo
 }
 logFailed() {
+  echo
   echo "Error: Running \`$1\` failed!"
 }
 logRunning() {
   echo "Generating Everything.agda by running \`$1\` in $(pwd):"
-}
-showCdIfNeeded() {
-  myPath="$(dirname "$0")"
-  if [ "${myPath}" != "." ]; then
-    echo "$ cd ${myPath}"
-  fi
+  echo
 }
 
 generator=GenerateEverythingIlc
-stackCmdName="stack exec --package ilc GenerateEverythingIlc"
+stackCmdName="stack exec --package ilc $generator"
 
-if which "${generator}" > /dev/null; then
-  logRunning "${generator}"
-  ${generator} && { echo; logDone; } || { logFailed "${generator}"; exit 1; }
-else
-  echo "\`${generator}\` is not installed (consider running \`cabal install\` to fix that)."
-  logRunning "$stackCmdName"
-  echo
-
-  eval $stackCmdName
-  ret=$?
-  echo
-  if [ "$ret" -ne 0 ]; then
-    logFailed "$stackCmdName"
-    exit 1
-  else
-    logDone
-  fi
-fi
+logRunning "$stackCmdName"
+eval $stackCmdName && logDone || { logFailed "$stackCmdName"; exit 1; }
 
 # vim: set ft=sh:

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
+- Agda-2.4.0.2
 - STMonadTrans-0.3.3
 - boxes-0.1.4
 - data-hash-0.2.0.0
@@ -29,11 +30,3 @@ compiler: ghc-7.8.4
 # Require a specific version of stack, using version ranges
 # require-stack-version: -any # Default
 # require-stack-version: >= 1.0.0
-
-# Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-
-# Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
This fixes the build failures on master and simplifies the build-related code.
Presumably, this will also simplify porting to new Agda versions (which will require updates to this code).