### PR TITLE
Update codebase to Agda 2.5.2-prerelease

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
 
 script:
   - stack --no-terminal --install-ghc build Agda ilc
-  - (mkdir -p ../stdlib; cd ../stdlib; curl -L https://github.com/agda/agda-stdlib/archive/v0.8.tar.gz|tar xz)
-
-  - echo "AGDA_LIB=$(dirname $PWD)/stdlib/agda-stdlib-0.8/src" > agdaCheck.sh.conf
+  - (mkdir -p ../agda-stdlib; cd ../agda-stdlib; curl -L https://github.com/agda/agda-stdlib/archive/v0.12.tar.gz|tar xz)
+  - mkdir ~/.agda; echo "standard-library" > ~/.agda/defaults; echo "$(dirname $PWD)/agda-stdlib/agda-stdlib-0.12/standard-library.agda-lib" > ~/.agda/libraries
   - ./agdaCheck.sh

--- a/Base/Change/Algebra.agda
+++ b/Base/Change/Algebra.agda
@@ -109,6 +109,11 @@ record ChangeAlgebraFamily {a p} ℓ {A : Set a} (P : A → Set p): Set (suc ℓ
   field
     change-algebra : ∀ x → ChangeAlgebra ℓ (P x)
 
+  {-
+  instance
+    change-algebra-extractor : ∀ {x} → ChangeAlgebra ℓ (P x)
+    change-algebra-extractor {x} = change-algebra x
+  -}
   module _ x where
     open ChangeAlgebra (change-algebra x) public
 
@@ -127,6 +132,10 @@ open Family public
     ; before to before₍_₎
     ; after to after₍_₎
     )
+
+-- XXX not clear this is ever used
+instance
+  change-algebra-family-inst = change-algebra₍_₎
 
 infixl 6 update′ diff′
 
@@ -158,7 +167,7 @@ Derivative₍_,_₎ : ∀ {a b p q c d} {A : Set a} {B : Set b} {P : A → Set p
   (f : P x → Q y) →
   (df : (px : P x) (dpx : Δ₍ x ₎ px) → Δ₍ y ₎ (f px)) →
   Set (p ⊔ q ⊔ c)
-Derivative₍ x , y ₎ f df = Derivative f df where
+Derivative₍ x , y ₎ f df = Derivative {{change-algebra₍ _ ₎}} {{change-algebra₍ _ ₎}} f df where
   CPx = change-algebra₍ x ₎
   CQy = change-algebra₍ y ₎
 
@@ -276,7 +285,8 @@ module FunctionChanges
       -- I have to write the type of funUpdateDiff without using changeAlgebra,
       -- so I just use the underlying implementations.
       funUpdateDiff : ∀ u v → funUpdate v (funDiff u v) ≡ u
-      changeAlgebra : ChangeAlgebra (a ⊔ b ⊔ c ⊔ d) (A → B)
+      instance
+        changeAlgebra : ChangeAlgebra (a ⊔ b ⊔ c ⊔ d) (A → B)
 
       changeAlgebra = record
         { Change = FunctionChange
@@ -355,7 +365,9 @@ module ListChanges
     update-diff-all [] [] = refl
     update-diff-all (px′ ∷ pxs′) (px ∷ pxs) = cong₂ _∷_ (update-diff₍ _ ₎ px′ px) (update-diff-all pxs′ pxs)
 
-    changeAlgebra : ChangeAlgebraFamily (c ⊔ a) (All P)
+    instance
+      changeAlgebra : ChangeAlgebraFamily (c ⊔ a) (All P)
+
     changeAlgebra = record
       { change-algebra = λ xs → record
         { Change = All′ Δ₍ _ ₎

--- a/Base/Change/Equivalence.agda
+++ b/Base/Change/Equivalence.agda
@@ -17,34 +17,34 @@ open import Base.Change.Equivalence.EqReasoning public
 module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
   -- By update-nil, if dx = nil x, then x ⊞ dx ≡ x.
   -- As a consequence, if dx ≙ nil x, then x ⊞ dx ≡ x
-  nil-is-⊞-unit : ∀ dx → dx ≙ nil x → x ⊞ dx ≡ x
+  nil-is-⊞-unit : ∀ (dx : Δ {{ca}} x) → dx ≙ nil x → x ⊞ dx ≡ x
   nil-is-⊞-unit dx dx≙nil-x =
     begin
       x ⊞ dx
     ≡⟨ proof dx≙nil-x ⟩
-      x ⊞ (nil x)
-    ≡⟨ update-nil x ⟩
+      x ⊞ (nil {{ca}} x)
+    ≡⟨ update-nil {{ca}} x ⟩
       x
     ∎
     where
       open ≡-Reasoning
 
   -- Here we prove the inverse:
-  ⊞-unit-is-nil : ∀ dx → x ⊞ dx ≡ x → dx ≙ nil x
+  ⊞-unit-is-nil : ∀ (dx : Δ {{ca}} x) → x ⊞ dx ≡ x → _≙_ {{ca}} dx (nil {{ca}} x)
   ⊞-unit-is-nil dx x⊞dx≡x = doe $
     begin
       x ⊞ dx
     ≡⟨ x⊞dx≡x ⟩
       x
-    ≡⟨ sym (update-nil x) ⟩
-      x ⊞ nil x
+    ≡⟨ sym (update-nil {{ca}} x) ⟩
+      x ⊞ nil {{ca}} x
     ∎
     where
       open ≡-Reasoning
 
   -- Let's show that nil x is d.o.e. to x ⊟ x
   nil-x-is-x⊟x : nil x ≙ x ⊟ x
-  nil-x-is-x⊟x = ≙-sym (⊞-unit-is-nil (x ⊟ x) (update-diff x x))
+  nil-x-is-x⊟x = ≙-sym (⊞-unit-is-nil (x ⊟ x) (update-diff {{ca}} x x))
 
   -- TODO: we want to show that all functions of interest respect
   -- delta-observational equivalence, so that two d.o.e. changes can be
@@ -65,11 +65,11 @@ module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
   -- equivalence.
 
   -- This results pairs with update-diff.
-  diff-update : ∀ {dx} → (x ⊞ dx) ⊟ x ≙ dx
+  diff-update : ∀ {dx : Δ {{ca}} x} → (x ⊞ dx) ⊟ x ≙ dx
   diff-update {dx} = doe lemma
     where
-      lemma : x ⊞ (x ⊞ dx ⊟ x) ≡ x ⊞ dx
-      lemma = update-diff (x ⊞ dx) x
+      lemma : _⊞_ {{ca}} x (x ⊞ dx ⊟ x) ≡ x ⊞ dx
+      lemma = update-diff {{ca}} (x ⊞ dx) x
 
 module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
   {{CA : ChangeAlgebra c A}} {{CB : ChangeAlgebra d B}} where
@@ -79,7 +79,7 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
   open FC.FunctionChange
 
   fun-change-respects : ∀ {x : A} {dx₁ dx₂ : Δ x} {f : A → B} {df₁ df₂} →
-    df₁ ≙ df₂ → dx₁ ≙ dx₂ → apply df₁ x dx₁ ≙ apply df₂ x dx₂
+    _≙_ {{changeAlgebra}} df₁ df₂ → dx₁ ≙ dx₂ → apply df₁ x dx₁ ≙ apply df₂ x dx₂
   fun-change-respects {x} {dx₁} {dx₂} {f} {df₁} {df₂} df₁≙df₂ dx₁≙dx₂ = doe lemma
     where
       open ≡-Reasoning
@@ -120,7 +120,7 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
   -- that's a stronger hypothesis, which doesn't give you extra guarantees. But
   -- here's the statement and proof, for completeness:
 
-  delta-ext₂ : ∀ {f : A → B} → ∀ {df dg : Δ f} → (∀ x dx₁ dx₂ → dx₁ ≙ dx₂ → apply df x dx₁ ≙ apply dg x dx₂) → df ≙ dg
+  delta-ext₂ : ∀ {f : A → B} → ∀ {df dg : Δ f} → (∀ x dx₁ dx₂ → _≙_ {{CA}} dx₁ dx₂ → apply df x dx₁ ≙ apply dg x dx₂) → df ≙ dg
   delta-ext₂ {f} {df} {dg} df-x-dx≙dg-x-dx = delta-ext (λ x dx → df-x-dx≙dg-x-dx x dx dx ≙-refl)
 
   -- We know that Derivative f (apply (nil f)) (by nil-is-derivative).
@@ -135,8 +135,8 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
     ≡⟨⟩
       (λ x → f x ⊞ apply df x (nil x))
     ≡⟨ ext (λ x → fdf x (nil x)) ⟩
-      (λ x → f (x ⊞ nil x))
-    ≡⟨ ext (λ x → cong f (update-nil x)) ⟩
+      (λ x → f (x ⊞ nil {{CA}} x))
+    ≡⟨ ext (λ x → cong f (update-nil {{CA}} x)) ⟩
       (λ x → f x)
     ≡⟨⟩
       f
@@ -167,17 +167,18 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
   -- (incorrectly) normal equality instead of delta-observational equivalence.
   deriv-zero :
     (f : A → B) → (df : (a : A) (da : Δ a) → Δ (f a)) → Derivative f df →
-    ∀ v → df v (nil v) ≙ nil (f v)
+    ∀ v → df v (nil {{CA}} v) ≙ nil {{CB}} (f v)
   deriv-zero f df proof v = doe lemma
     where
       open ≡-Reasoning
-      lemma : f v ⊞ df v (nil v) ≡ f v ⊞ nil (f v)
+      lemma : f v ⊞ df v (nil v) ≡ f v ⊞ nil {{CB}} (f v)
       lemma =
         begin
-          f v ⊞ df v (nil v)
-        ≡⟨ proof v (nil v) ⟩
-          f (v ⊞ (nil v))
-        ≡⟨ cong f (update-nil v) ⟩
+          f v ⊞ df v (nil {{CA}} v)
+        ≡⟨ proof v (nil {{CA}} v) ⟩
+          f (v ⊞ (nil {{CA}} v))
+        ≡⟨ cong f (update-nil {{CA}} v) ⟩
           f v
-        ≡⟨ sym (update-nil (f v)) ⟩
-          f v ⊞ nil (f v) ∎
+        ≡⟨ sym (update-nil {{CB}} (f v)) ⟩
+          f v ⊞ nil {{CB}} (f v)
+        ∎

--- a/Base/Change/Equivalence/Base.agda
+++ b/Base/Change/Equivalence/Base.agda
@@ -17,7 +17,7 @@ module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
 
   -- To avoid unification problems, use a one-field record (a Haskell "newtype")
   -- instead of a "type synonym".
-  record _≙_ dx dy : Set a where
+  record _≙_ (dx dy : Δ {{ca}} x) : Set a where
     -- doe = Delta-Observational Equivalence.
     constructor doe
     field

--- a/Base/Change/Equivalence/EqReasoning.agda
+++ b/Base/Change/Equivalence/EqReasoning.agda
@@ -20,5 +20,5 @@ module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
   import Relation.Binary.EqReasoning as EqR
 
   module ≙-Reasoning where
-    open EqR (≙-setoid {x = x}) public
+    open EqR (≙-setoid {{ca}} {x = x}) public
       renaming (_≈⟨_⟩_ to _≙⟨_⟩_)

--- a/Base/Change/Products.agda
+++ b/Base/Change/Products.agda
@@ -64,17 +64,18 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : Ch
         v
       ∎
 
-  changeAlgebra : ChangeAlgebra ℓ (A × B)
-  changeAlgebra = record
-    { Change = PChange
-    ; update = _⊕_
-    ; diff = _⊝_
-    ; nil = p-nil
-    ; isChangeAlgebra = record
-      { update-diff = p-update-diff
-      ; update-nil = p-update-nil
+  instance
+    changeAlgebra : ChangeAlgebra ℓ (A × B)
+    changeAlgebra = record
+      { Change = PChange
+      ; update = _⊕_
+      ; diff = _⊝_
+      ; nil = p-nil
+      ; isChangeAlgebra = record
+        { update-diff = p-update-diff
+        ; update-nil = p-update-nil
+        }
       }
-    }
 
   proj₁′ : (v : A × B) → Δ v → Δ (proj₁ v)
   proj₁′ (a , b) (da , db) = da
@@ -106,8 +107,9 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : Ch
   proj₂′Derivative : Derivative proj₂ proj₂′
   proj₂′Derivative v dv = refl
 
-  B→A×B = FunctionChanges.changeAlgebra B (A × B)
-  A→B→A×B = FunctionChanges.changeAlgebra A (B → A × B) {{CA}} {{B→A×B}}
+  instance
+    B→A×B = FunctionChanges.changeAlgebra {c = ℓ} {d = ℓ} B (A × B) {{CB}} {{changeAlgebra}}
+    A→B→A×B = FunctionChanges.changeAlgebra {d = ℓ} A (B → A × B) {{CA}} {{B→A×B}}
 
   -- Morally, the following is a change:
   -- What one could wrongly expect to be the derivative of the constructor:
@@ -155,12 +157,13 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : Ch
   uncurry₀ f (a , b) = f a b
 
   module _ {C : Set ℓ} {{CC : ChangeAlgebra ℓ C}} where
-    B→C : ChangeAlgebra ℓ (B → C)
-    B→C = FunctionChanges.changeAlgebra B C
-    A→B→C : ChangeAlgebra ℓ (A → B → C)
-    A→B→C = FunctionChanges.changeAlgebra A (B → C)
-    A×B→C : ChangeAlgebra ℓ (A × B → C)
-    A×B→C = FunctionChanges.changeAlgebra (A × B) C
+    instance
+      B→C : ChangeAlgebra ℓ (B → C)
+      B→C = FunctionChanges.changeAlgebra B C
+      A→B→C : ChangeAlgebra ℓ (A → B → C)
+      A→B→C = FunctionChanges.changeAlgebra A (B → C)
+      A×B→C : ChangeAlgebra ℓ (A × B → C)
+      A×B→C = FunctionChanges.changeAlgebra (A × B) C
     open FunctionChanges using (apply; correct)
 
     uncurry₀′-realizer : (f : A → B → C) → Δ f → (p : A × B) → Δ p → Δ (uncurry₀ f p)

--- a/Base/Change/Sums.agda
+++ b/Base/Change/Sums.agda
@@ -43,28 +43,29 @@ module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra ℓ X}} {{CY : Change
   s-update-nil (inj₁ x) = cong inj₁ (update-nil x)
   s-update-nil (inj₂ y) = cong inj₂ (update-nil y)
 
-  changeAlgebra : ChangeAlgebra ℓ (X ⊎ Y)
-  changeAlgebra = record
-    { Change = SumChange
-    ; update = _⊕_
-    ; diff = _⊝_
-    ; nil = s-nil
-    ; isChangeAlgebra = record
-      { update-diff = s-update-diff
-      ; update-nil = s-update-nil
+  instance
+    changeAlgebra : ChangeAlgebra ℓ (X ⊎ Y)
+    changeAlgebra = record
+      { Change = SumChange
+      ; update = _⊕_
+      ; diff = _⊝_
+      ; nil = s-nil
+      ; isChangeAlgebra = record
+        { update-diff = s-update-diff
+        ; update-nil = s-update-nil
+        }
       }
-    }
 
-  inj₁′ : (x : X) → (dx : Δ x) → Δ (inj₁ x)
+  inj₁′ : (x : X) → (dx : Δ x) → Δ {{changeAlgebra}} (inj₁ x)
   inj₁′ x dx = ch₁ dx
 
-  inj₁′Derivative : Derivative inj₁ inj₁′
+  inj₁′Derivative : Derivative {{CX}} {{changeAlgebra}} inj₁ inj₁′
   inj₁′Derivative x dx = refl
 
-  inj₂′ : (y : Y) → (dy : Δ y) → Δ (inj₂ y)
+  inj₂′ : (y : Y) → (dy : Δ y) → Δ {{changeAlgebra}} (inj₂ y)
   inj₂′ y dy = ch₂ dy
 
-  inj₂′Derivative : Derivative inj₂ inj₂′
+  inj₂′Derivative : Derivative {{CY}} {{changeAlgebra}} inj₂ inj₂′
   inj₂′Derivative y dy = refl
 
   -- Elimination form for sums. This is a less dependently-typed version of
@@ -74,12 +75,13 @@ module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra ℓ X}} {{CY : Change
   match f g (inj₂ y) = g y
 
   module _ {Z : Set ℓ} {{CZ : ChangeAlgebra ℓ Z}} where
-    X→Z = FunctionChanges.changeAlgebra X Z
-    --module ΔX→Z = FunctionChanges X Z {{CX}} {{CZ}}
-    Y→Z = FunctionChanges.changeAlgebra Y Z
-    --module ΔY→Z = FunctionChanges Y Z {{CY}} {{CZ}}
-    X⊎Y→Z = FunctionChanges.changeAlgebra (X ⊎ Y) Z
-    Y→Z→X⊎Y→Z = FunctionChanges.changeAlgebra (Y → Z) (X ⊎ Y → Z)
+    instance
+      X→Z = FunctionChanges.changeAlgebra X Z {{CX}} {{CZ}}
+      --module ΔX→Z = FunctionChanges X Z {{CX}} {{CZ}}
+      Y→Z = FunctionChanges.changeAlgebra Y Z {{CY}} {{CZ}}
+      --module ΔY→Z = FunctionChanges Y Z {{CY}} {{CZ}}
+      X⊎Y→Z = FunctionChanges.changeAlgebra (X ⊎ Y) Z {{changeAlgebra}} {{CZ}}
+      Y→Z→X⊎Y→Z = FunctionChanges.changeAlgebra (Y → Z) (X ⊎ Y → Z) {{Y→Z}} {{X⊎Y→Z}}
 
     open FunctionChanges using (apply; correct)
 

--- a/Base/Data/ContextList.agda
+++ b/Base/Data/ContextList.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- INCREMENTAL λ-CALCULUS
+--
+-- Reexport Data.List from the standard library.
+--
+-- Here we expose different names, for use in Contexts.
+------------------------------------------------------------------------
+
+module Base.Data.ContextList where
+
+import Data.List as List
+open List public
+  using ()
+  renaming
+    ( [] to ∅ ; _∷_ to _•_
+    ; map to mapContext
+    )

--- a/Base/Data/DependentList.agda
+++ b/Base/Data/DependentList.agda
@@ -12,7 +12,6 @@
 
 module Base.Data.DependentList where
 
-open import Base.Data.ContextList public
 open import Data.List.All public
   using
     ( head

--- a/Base/Data/DependentList.agda
+++ b/Base/Data/DependentList.agda
@@ -12,6 +12,7 @@
 
 module Base.Data.DependentList where
 
+open import Base.Data.ContextList public
 open import Data.List.All public
   using
     ( head

--- a/Base/Denotation/Environment.agda
+++ b/Base/Denotation/Environment.agda
@@ -22,10 +22,7 @@ open import Relation.Binary.PropositionalEquality
 
 open import Base.Syntax.Context Type
 open import Base.Denotation.Notation
-import Base.Data.DependentList as DependentList
-
-open DependentList public using (∅ ; _•_)
-open DependentList
+open import Base.Data.DependentList as DependentList
 
 private
   meaningOfType : Meaning Type

--- a/Base/Denotation/Environment.agda
+++ b/Base/Denotation/Environment.agda
@@ -64,21 +64,21 @@ instance
 -- Properties
 
 ⟦⟧-≼-trans : ∀ {Γ₃ Γ₁ Γ₂} → (Γ′ : Γ₁ ≼ Γ₂) (Γ″ : Γ₂ ≼ Γ₃) →
-  ∀ (ρ : ⟦ Γ₃ ⟧) → ⟦ ≼-trans Γ′ Γ″ ⟧ ρ ≡ ⟦ Γ′ ⟧ (⟦ Γ″ ⟧ ρ)
+   ∀ (ρ : ⟦ Γ₃ ⟧) → ⟦_⟧ {{meaningOf≼}} (≼-trans Γ′ Γ″) ρ ≡ ⟦_⟧ {{meaningOf≼}} Γ′ (⟦_⟧ {{meaningOf≼}} Γ″ ρ)
 ⟦⟧-≼-trans Γ′ ∅ ∅ = refl
 ⟦⟧-≼-trans (keep τ • Γ′) (keep .τ • Γ″) (v • ρ) = cong₂ _•_ refl (⟦⟧-≼-trans Γ′ Γ″ ρ)
 ⟦⟧-≼-trans (drop τ • Γ′) (keep .τ • Γ″) (v • ρ) = ⟦⟧-≼-trans Γ′ Γ″ ρ
 ⟦⟧-≼-trans Γ′ (drop τ • Γ″) (v • ρ) = ⟦⟧-≼-trans Γ′ Γ″ ρ
 
 ⟦⟧-≼-refl : ∀ {Γ : Context} →
-  ∀ (ρ : ⟦ Γ ⟧) → ⟦ ≼-refl ⟧ ρ ≡ ρ
+  ∀ (ρ : ⟦ Γ ⟧) → ⟦_⟧ {{meaningOf≼}} ≼-refl ρ ≡ ρ
 ⟦⟧-≼-refl {∅} ∅ = refl
 ⟦⟧-≼-refl {τ • Γ} (v • ρ) = cong₂ _•_ refl (⟦⟧-≼-refl ρ)
 
 -- SOUNDNESS of variable lifting
 
 weaken-var-sound : ∀ {Γ₁ Γ₂ τ} (Γ′ : Γ₁ ≼ Γ₂) (x : Var Γ₁ τ) →
-  ∀ (ρ : ⟦ Γ₂ ⟧) → ⟦ weaken-var Γ′ x ⟧ ρ ≡ ⟦ x ⟧ (⟦ Γ′ ⟧ ρ)
+  ∀ (ρ : ⟦ Γ₂ ⟧) → ⟦_⟧ {{meaningOfVar}} (weaken-var Γ′ x) ρ ≡ ⟦_⟧ {{meaningOfVar}} x ( ⟦_⟧ {{meaningOf≼}} Γ′  ρ)
 weaken-var-sound ∅ () ρ
 weaken-var-sound (keep τ • Γ′) this (v • ρ) = refl
 weaken-var-sound (keep τ • Γ′) (that x) (v • ρ) = weaken-var-sound Γ′ x ρ

--- a/Base/Denotation/Environment.agda
+++ b/Base/Denotation/Environment.agda
@@ -25,14 +25,16 @@ open import Base.Denotation.Notation
 open import Base.Data.DependentList as DependentList
 
 private
-  meaningOfType : Meaning Type
-  meaningOfType = meaning ⟦_⟧Type
+  instance
+    meaningOfType : Meaning Type
+    meaningOfType = meaning ⟦_⟧Type
 
 ⟦_⟧Context : Context → Set ℓ
 ⟦_⟧Context = DependentList ⟦_⟧Type
 
-meaningOfContext : Meaning Context
-meaningOfContext = meaning ⟦_⟧Context
+instance
+  meaningOfContext : Meaning Context
+  meaningOfContext = meaning ⟦_⟧Context
 
 -- VARIABLES
 
@@ -42,8 +44,9 @@ meaningOfContext = meaning ⟦_⟧Context
 ⟦ this ⟧Var (v • ρ) = v
 ⟦ that x ⟧Var (v • ρ) = ⟦ x ⟧Var ρ
 
-meaningOfVar : ∀ {Γ τ} → Meaning (Var Γ τ)
-meaningOfVar = meaning ⟦_⟧Var
+instance
+  meaningOfVar : ∀ {Γ τ} → Meaning (Var Γ τ)
+  meaningOfVar = meaning ⟦_⟧Var
 
 -- WEAKENING
 
@@ -54,8 +57,9 @@ meaningOfVar = meaning ⟦_⟧Var
 ⟦ keep τ • Γ′ ⟧≼ (v • ρ) = v • ⟦ Γ′ ⟧≼ ρ
 ⟦ drop τ • Γ′ ⟧≼ (v • ρ) = ⟦ Γ′ ⟧≼ ρ
 
-meaningOf≼ : ∀ {Γ₁ Γ₂} → Meaning (Γ₁ ≼ Γ₂)
-meaningOf≼ = meaning ⟦_⟧≼
+instance
+  meaningOf≼ : ∀ {Γ₁ Γ₂} → Meaning (Γ₁ ≼ Γ₂)
+  meaningOf≼ = meaning ⟦_⟧≼
 
 -- Properties
 

--- a/Base/Syntax/Context.agda
+++ b/Base/Syntax/Context.agda
@@ -21,7 +21,7 @@ open import Relation.Binary.PropositionalEquality
 -- ===============
 
 import Data.List as List
-open import Base.Data.ContextList
+open import Base.Data.ContextList public
 
 Context : Set
 Context = List.List Type

--- a/Base/Syntax/Context.agda
+++ b/Base/Syntax/Context.agda
@@ -21,7 +21,7 @@ open import Relation.Binary.PropositionalEquality
 -- ===============
 
 import Data.List as List
-open import Base.Data.ContextList public
+open import Base.Data.ContextList
 
 Context : Set
 Context = List.List Type

--- a/Base/Syntax/Context.agda
+++ b/Base/Syntax/Context.agda
@@ -21,12 +21,7 @@ open import Relation.Binary.PropositionalEquality
 -- ===============
 
 import Data.List as List
-open List public
-  using ()
-  renaming
-    ( [] to ∅ ; _∷_ to _•_
-    ; map to mapContext
-    )
+open import Base.Data.ContextList public
 
 Context : Set
 Context = List.List Type

--- a/Base/Syntax/Vars.agda
+++ b/Base/Syntax/Vars.agda
@@ -21,7 +21,7 @@ open import Data.Bool
 
 -- Sets of variables
 
-open import Base.Data.DependentList public
+open import Base.Data.DependentList
 
 Free : Type → Set
 Free _ = Bool

--- a/Nehemiah/Change/Correctness.agda
+++ b/Nehemiah/Change/Correctness.agda
@@ -34,7 +34,7 @@ import Parametric.Change.Correctness
   apply-base diff-base nil-base
   ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧
   meaning-⊕-base meaning-⊝-base meaning-onil-base
-  change-algebra-base-family specification-structure
+  specification-structure
   deriveConst implementation-structure as Correctness
 
 derive-const-correct : Correctness.Structure

--- a/Nehemiah/Change/Implementation.agda
+++ b/Nehemiah/Change/Implementation.agda
@@ -24,7 +24,7 @@ open import Structure.Bag.Nehemiah
 
 import Parametric.Change.Implementation
     Const ⟦_⟧Base ⟦_⟧Const ΔBase
-    change-algebra-base-family specification-structure
+    specification-structure
     ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧ deriveConst as Implementation
 
 private

--- a/Nehemiah/Change/Specification.agda
+++ b/Nehemiah/Change/Specification.agda
@@ -17,7 +17,7 @@ open import Data.Integer
 open import Theorem.Groups-Nehemiah
 
 import Parametric.Change.Specification
-  Const ⟦_⟧Base ⟦_⟧Const change-algebra-base-family as Specification
+  Const ⟦_⟧Base ⟦_⟧Const as Specification
 
 private
   ⟦_⟧ΔConst : ∀ {Σ τ} → (c  : Const Σ τ) (ρ : ⟦ Σ ⟧) → Δ₍ Σ ₎ ρ → Δ₍ τ ₎ (⟦ c ⟧Const ρ)

--- a/Nehemiah/Change/Validity.agda
+++ b/Nehemiah/Change/Validity.agda
@@ -28,5 +28,5 @@ instance
   change-algebra-base-family : ChangeAlgebraFamily zero ⟦_⟧Base
   change-algebra-base-family = family change-algebra-base
 
---open Validity.Structure change-algebra-base-family public --XXX agda/agda#1985.
+--open Validity.Structure {{change-algebra-base-family}} public --XXX agda/agda#1985.
 open Validity.Structure public

--- a/Nehemiah/Change/Validity.agda
+++ b/Nehemiah/Change/Validity.agda
@@ -21,10 +21,12 @@ open import Base.Change.Algebra
 open import Level
 
 change-algebra-base : ∀ ι → ChangeAlgebra zero ⟦ ι ⟧Base
-change-algebra-base base-int = GroupChanges.changeAlgebra ℤ
-change-algebra-base base-bag = GroupChanges.changeAlgebra Bag
+change-algebra-base base-int = GroupChanges.changeAlgebra ℤ {{abelian-int}}
+change-algebra-base base-bag = GroupChanges.changeAlgebra Bag {{abelian-bag}}
 
-change-algebra-base-family : ChangeAlgebraFamily zero ⟦_⟧Base
-change-algebra-base-family = family change-algebra-base
+instance
+  change-algebra-base-family : ChangeAlgebraFamily zero ⟦_⟧Base
+  change-algebra-base-family = family change-algebra-base
 
-open Validity.Structure change-algebra-base-family public
+--open Validity.Structure change-algebra-base-family public --XXX agda/agda#1985.
+open Validity.Structure public

--- a/Nehemiah/Syntax/Term.agda
+++ b/Nehemiah/Syntax/Term.agda
@@ -25,8 +25,15 @@ data Const : Term.Structure where
   flatmap-const : Const ((int ⇒ bag) • bag • ∅) (bag)
   sum-const : Const (bag • ∅) (int)
 
-open Term.Structure Const public
 
+--open Term.Structure --works
+open Term.Structure Const --fails, even with the rest disabled.
+{-
+An internal error has occurred. Please report this as a bug.
+Location of the error: src/full/Agda/TypeChecking/Substitute.hs:183
+-}
+
+{-
 -- Shorthands of constants
 
 pattern intlit n = const (intlit-const n) ∅
@@ -38,3 +45,4 @@ pattern union s t = const union-const (s • t • ∅)
 pattern negate t = const negate-const (t • ∅)
 pattern flatmap s t = const flatmap-const (s • t • ∅)
 pattern sum t = const sum-const (t • ∅)
+-}

--- a/Nehemiah/Syntax/Term.agda
+++ b/Nehemiah/Syntax/Term.agda
@@ -26,14 +26,16 @@ data Const : Term.Structure where
   sum-const : Const (bag • ∅) (int)
 
 
---open Term.Structure --works
-open Term.Structure Const --fails, even with the rest disabled.
-{-
-An internal error has occurred. Please report this as a bug.
-Location of the error: src/full/Agda/TypeChecking/Substitute.hs:183
--}
+open Term.Structure Const public
 
-{-
+-- Import Base.Data.DependentList again here, as part of the workaround for
+-- agda/agda#1985; see Parametric.Syntax.Term for info.
+--
+-- XXX This import is needed to define the patterns in the right scope; if we
+-- don't, • gets bound to a different occurrence, and we notice that during
+-- typechecking, which happens at use site.
+open import Base.Data.DependentList public
+
 -- Shorthands of constants
 
 pattern intlit n = const (intlit-const n) ∅
@@ -45,4 +47,3 @@ pattern union s t = const union-const (s • t • ∅)
 pattern negate t = const negate-const (t • ∅)
 pattern flatmap s t = const flatmap-const (s • t • ∅)
 pattern sum t = const sum-const (t • ∅)
--}

--- a/Parametric/Change/Correctness.agda
+++ b/Parametric/Change/Correctness.agda
@@ -38,7 +38,7 @@ module Parametric.Change.Correctness
       ⟦_⟧Base ⟦_⟧Const ΔBase apply-base diff-base nil-base ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧)
     {{validity-structure : Validity.Structure ⟦_⟧Base}}
     (specification-structure : Specification.Structure
-      Const ⟦_⟧Base ⟦_⟧Const validity-structure)
+      Const ⟦_⟧Base ⟦_⟧Const)
     (derive-const : Derive.Structure Const ΔBase)
     (implementation-structure : Implementation.Structure
       Const ⟦_⟧Base ⟦_⟧Const ΔBase
@@ -50,7 +50,7 @@ open Type.Structure Base
 open Term.Structure Base Const
 open Value.Structure Base ⟦_⟧Base
 open Evaluation.Structure Const ⟦_⟧Base ⟦_⟧Const
-open Validity.Structure ⟦_⟧Base validity-structure
+open Validity.Structure ⟦_⟧Base
 open Specification.Structure specification-structure
 open ChangeType.Structure Base ΔBase
 open ChangeTerm.Structure Const ΔBase apply-base diff-base nil-base

--- a/Parametric/Change/Correctness.agda
+++ b/Parametric/Change/Correctness.agda
@@ -5,6 +5,7 @@
 ------------------------------------------------------------------------
 
 import Parametric.Syntax.Type as Type
+open import Base.Data.DependentList
 import Parametric.Syntax.Term as Term
 import Parametric.Denotation.Value as Value
 import Parametric.Denotation.Evaluation as Evaluation

--- a/Parametric/Change/Correctness.agda
+++ b/Parametric/Change/Correctness.agda
@@ -35,13 +35,13 @@ module Parametric.Change.Correctness
       ⟦_⟧Base ⟦_⟧Const ΔBase apply-base diff-base nil-base ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧)
     (meaning-onil-base : ChangeEvaluation.NilStructure
       ⟦_⟧Base ⟦_⟧Const ΔBase apply-base diff-base nil-base ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧)
-    (validity-structure : Validity.Structure ⟦_⟧Base)
+    {{validity-structure : Validity.Structure ⟦_⟧Base}}
     (specification-structure : Specification.Structure
       Const ⟦_⟧Base ⟦_⟧Const validity-structure)
     (derive-const : Derive.Structure Const ΔBase)
     (implementation-structure : Implementation.Structure
       Const ⟦_⟧Base ⟦_⟧Const ΔBase
-      validity-structure specification-structure
+      specification-structure
       ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧ derive-const)
   where
 
@@ -50,8 +50,7 @@ open Term.Structure Base Const
 open Value.Structure Base ⟦_⟧Base
 open Evaluation.Structure Const ⟦_⟧Base ⟦_⟧Const
 open Validity.Structure ⟦_⟧Base validity-structure
-open Specification.Structure
-  Const ⟦_⟧Base ⟦_⟧Const validity-structure specification-structure
+open Specification.Structure specification-structure
 open ChangeType.Structure Base ΔBase
 open ChangeTerm.Structure Const ΔBase apply-base diff-base nil-base
 open ChangeValue.Structure Const ⟦_⟧Base ΔBase ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧
@@ -61,10 +60,7 @@ open ChangeEvaluation.Structure
   ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧
   meaning-⊕-base meaning-⊝-base meaning-onil-base
 open Derive.Structure Const ΔBase derive-const
-open Implementation.Structure
-  Const ⟦_⟧Base ⟦_⟧Const ΔBase validity-structure specification-structure
-  ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧ derive-const implementation-structure
-
+open Implementation.Structure implementation-structure
 -- The denotational properties of the `derive` transformation.
 -- In particular, the main theorem about it producing the correct
 -- incremental behavior.

--- a/Parametric/Change/Derive.agda
+++ b/Parametric/Change/Derive.agda
@@ -5,6 +5,7 @@
 ------------------------------------------------------------------------
 
 import Parametric.Syntax.Type as Type
+open import Base.Data.DependentList
 import Parametric.Syntax.Term as Term
 import Parametric.Change.Type as ChangeType
 

--- a/Parametric/Change/Evaluation.agda
+++ b/Parametric/Change/Evaluation.agda
@@ -5,6 +5,7 @@
 ------------------------------------------------------------------------
 
 import Parametric.Syntax.Type as Type
+open import Base.Data.DependentList
 import Parametric.Syntax.Term as Term
 import Parametric.Denotation.Value as Value
 import Parametric.Denotation.Evaluation as Evaluation

--- a/Parametric/Change/Implementation.agda
+++ b/Parametric/Change/Implementation.agda
@@ -20,7 +20,7 @@ module Parametric.Change.Implementation
     (⟦_⟧Base : Value.Structure Base)
     (⟦_⟧Const : Evaluation.Structure Const ⟦_⟧Base)
     (ΔBase : ChangeType.Structure Base)
-    (validity-structure : Validity.Structure ⟦_⟧Base)
+    {{validity-structure : Validity.Structure ⟦_⟧Base}}
     (specification-structure : Specification.Structure
        Const ⟦_⟧Base ⟦_⟧Const validity-structure)
     (⟦apply-base⟧ : ChangeValue.ApplyStructure Const ⟦_⟧Base ΔBase)
@@ -34,8 +34,7 @@ open Term.Structure Base Const
 open Value.Structure Base ⟦_⟧Base
 open Evaluation.Structure Const ⟦_⟧Base ⟦_⟧Const
 open Validity.Structure ⟦_⟧Base validity-structure
-open Specification.Structure
-  Const ⟦_⟧Base ⟦_⟧Const validity-structure specification-structure
+open Specification.Structure specification-structure
 open ChangeType.Structure Base ΔBase
 open ChangeValue.Structure Const ⟦_⟧Base ΔBase ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧
 open Derive.Structure Const ΔBase derive-const
@@ -133,7 +132,7 @@ record Structure : Set₁ where
 
   -- A property relating `alternate` and the subcontext relation Γ≼ΔΓ
   ⟦Γ≼ΔΓ⟧ : ∀ {Γ} (ρ : ⟦ Γ ⟧) (dρ : ⟦ mapContext ΔType Γ ⟧) →
-    ρ ≡ ⟦ Γ≼ΔΓ ⟧ (alternate ρ dρ)
+    ρ ≡ ⟦ Γ≼ΔΓ ⟧≼ (alternate ρ dρ)
   ⟦Γ≼ΔΓ⟧ ∅ ∅ = refl
   ⟦Γ≼ΔΓ⟧ (v • ρ) (dv • dρ) = cong₂ _•_ refl (⟦Γ≼ΔΓ⟧ ρ dρ)
 

--- a/Parametric/Change/Implementation.agda
+++ b/Parametric/Change/Implementation.agda
@@ -23,7 +23,7 @@ module Parametric.Change.Implementation
     (ΔBase : ChangeType.Structure Base)
     {{validity-structure : Validity.Structure ⟦_⟧Base}}
     (specification-structure : Specification.Structure
-       Const ⟦_⟧Base ⟦_⟧Const validity-structure)
+       Const ⟦_⟧Base ⟦_⟧Const)
     (⟦apply-base⟧ : ChangeValue.ApplyStructure Const ⟦_⟧Base ΔBase)
     (⟦diff-base⟧ : ChangeValue.DiffStructure Const ⟦_⟧Base ΔBase)
     (⟦nil-base⟧ : ChangeValue.NilStructure Const ⟦_⟧Base ΔBase)
@@ -34,7 +34,7 @@ open Type.Structure Base
 open Term.Structure Base Const
 open Value.Structure Base ⟦_⟧Base
 open Evaluation.Structure Const ⟦_⟧Base ⟦_⟧Const
-open Validity.Structure ⟦_⟧Base validity-structure
+open Validity.Structure ⟦_⟧Base
 open Specification.Structure specification-structure
 open ChangeType.Structure Base ΔBase
 open ChangeValue.Structure Const ⟦_⟧Base ΔBase ⟦apply-base⟧ ⟦diff-base⟧ ⟦nil-base⟧

--- a/Parametric/Change/Implementation.agda
+++ b/Parametric/Change/Implementation.agda
@@ -5,6 +5,7 @@
 ------------------------------------------------------------------------
 
 import Parametric.Syntax.Type as Type
+open import Base.Data.DependentList
 import Parametric.Syntax.Term as Term
 import Parametric.Denotation.Value as Value
 import Parametric.Denotation.Evaluation as Evaluation

--- a/Parametric/Change/Specification.agda
+++ b/Parametric/Change/Specification.agda
@@ -16,14 +16,14 @@ module Parametric.Change.Specification
     (Const : Term.Structure Base)
     (⟦_⟧Base : Value.Structure Base)
     (⟦_⟧Const : Evaluation.Structure Const ⟦_⟧Base)
-    (validity-structure : Validity.Structure ⟦_⟧Base)
+    {{validity-structure : Validity.Structure ⟦_⟧Base}}
   where
 
 open Type.Structure Base
 open Term.Structure Base Const
 open Value.Structure Base ⟦_⟧Base
 open Evaluation.Structure Const ⟦_⟧Base ⟦_⟧Const
-open Validity.Structure ⟦_⟧Base validity-structure
+open Validity.Structure ⟦_⟧Base
 
 open import Base.Denotation.Notation
 open import Relation.Binary.PropositionalEquality

--- a/Parametric/Change/Specification.agda
+++ b/Parametric/Change/Specification.agda
@@ -5,6 +5,7 @@
 ------------------------------------------------------------------------
 
 import Parametric.Syntax.Type as Type
+open import Base.Data.DependentList
 import Parametric.Syntax.Term as Term
 import Parametric.Denotation.Value as Value
 import Parametric.Denotation.Evaluation as Evaluation

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -35,9 +35,10 @@ module Structure (change-algebra-base : Structure) where
     )
 
   -- We provide: change algebra for every type
-  change-algebra : ∀ τ → ChangeAlgebra zero ⟦ τ ⟧Type
-  change-algebra (base ι) = change-algebra₍ ι ₎
-  change-algebra (τ₁ ⇒ τ₂) = CA.FunctionChanges.changeAlgebra _ _ {{change-algebra τ₁}} {{change-algebra τ₂}}
+  instance
+    change-algebra : ∀ τ → ChangeAlgebra zero ⟦ τ ⟧Type
+    change-algebra (base ι) = change-algebra₍_₎ {{change-algebra-base}} ι
+    change-algebra (τ₁ ⇒ τ₂) = CA.FunctionChanges.changeAlgebra _ _ {{change-algebra τ₁}} {{change-algebra τ₂}}
 
   change-algebra-family : ChangeAlgebraFamily zero ⟦_⟧Type
   change-algebra-family = family change-algebra

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -46,7 +46,7 @@ module Structure (change-algebra-base : Structure) where
   -- function changes
 
   module _ {τ₁ τ₂ : Type} where
-    open FunctionChanges.FunctionChange _ _ {{change-algebra τ₁}} {{change-algebra τ₂}} public
+    open FunctionChanges.FunctionChange public
       renaming
         ( correct to is-valid
         ; apply to call-change

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -54,9 +54,11 @@ module Structure (change-algebra-base : Structure) where
 
   -- We also provide: change environments (aka. environment changes).
 
+  {-
   open ListChanges ⟦_⟧Type {{change-algebra-family}} public using () renaming
     ( changeAlgebra to environment-changes
     )
 
   after-env : ∀ {Γ : Context} → {ρ : ⟦ Γ ⟧} (dρ : Δ₍  Γ ₎ ρ) → ⟦ Γ ⟧
   after-env {Γ} = after₍ Γ ₎
+  -}

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -55,11 +55,9 @@ module Structure (change-algebra-base : Structure) where
 
   -- We also provide: change environments (aka. environment changes).
 
-  {-
   open ListChanges ⟦_⟧Type {{change-algebra-family}} public using () renaming
     ( changeAlgebra to environment-changes
     )
 
-  after-env : ∀ {Γ : Context} → {ρ : ⟦ Γ ⟧} (dρ : Δ₍  Γ ₎ ρ) → ⟦ Γ ⟧
-  after-env {Γ} = after₍ Γ ₎
-  -}
+  after-env : ∀ {Γ : Context} → {ρ : ⟦ Γ ⟧} (dρ : Δ₍_₎ {{environment-changes}} Γ ρ) → ⟦ Γ ⟧
+  after-env {Γ} = after₍_₎ Γ

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -6,6 +6,8 @@
 
 import Parametric.Syntax.Type as Type
 import Parametric.Denotation.Value as Value
+open import Base.Change.Algebra as CA
+  using (ChangeAlgebraFamily)
 
 module Parametric.Change.Validity
     {Base : Type.Structure}
@@ -18,8 +20,6 @@ open Value.Structure Base ⟦_⟧Base
 open import Base.Denotation.Notation public
 
 open import Relation.Binary.PropositionalEquality
-open import Base.Change.Algebra as CA
-  using (ChangeAlgebraFamily)
 open import Level
 
 -- Extension Point: Change algebras for base types

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -40,8 +40,8 @@ module Structure (change-algebra-base : Structure) where
     change-algebra (base ι) = change-algebra₍_₎ {{change-algebra-base}} ι
     change-algebra (τ₁ ⇒ τ₂) = CA.FunctionChanges.changeAlgebra _ _ {{change-algebra τ₁}} {{change-algebra τ₂}}
 
-  change-algebra-family : ChangeAlgebraFamily zero ⟦_⟧Type
-  change-algebra-family = family change-algebra
+    change-algebra-family : ChangeAlgebraFamily zero ⟦_⟧Type
+    change-algebra-family = family change-algebra
 
   -- function changes
 

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -46,7 +46,7 @@ module Structure (change-algebra-base : Structure) where
   -- function changes
 
   module _ {τ₁ τ₂ : Type} where
-    open FunctionChanges.FunctionChange public
+    open FunctionChanges.FunctionChange {{change-algebra τ₁}} {{change-algebra τ₂}} public
       renaming
         ( correct to is-valid
         ; apply to call-change

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -26,7 +26,7 @@ open import Level
 Structure : Set₁
 Structure = ChangeAlgebraFamily zero ⟦_⟧Base
 
-module Structure (change-algebra-base : Structure) where
+module Structure {{change-algebra-base : Structure}} where
   -- change algebras
 
   open CA public renaming

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -58,5 +58,5 @@ module Structure (change-algebra-base : Structure) where
     ( changeAlgebra to environment-changes
     )
 
-  after-env : ∀ {Γ : Context} → {ρ : ⟦ Γ ⟧} (dρ : Δ₍_₎ {{environment-changes}} Γ ρ) → ⟦ Γ ⟧
+  after-env : ∀ {Γ : Context} → {ρ : ⟦ Γ ⟧} (dρ : Δ₍ Γ ₎ ρ) → ⟦ Γ ⟧
   after-env {Γ} = after₍_₎ Γ

--- a/Parametric/Change/Value.agda
+++ b/Parametric/Change/Value.agda
@@ -6,6 +6,7 @@
 
 import Parametric.Syntax.Type as Type
 import Parametric.Syntax.Term as Term
+open import Base.Data.DependentList
 import Parametric.Denotation.Value as Value
 import Parametric.Change.Type as ChangeType
 

--- a/Parametric/Denotation/CachingMEvaluation.agda
+++ b/Parametric/Denotation/CachingMEvaluation.agda
@@ -6,6 +6,7 @@
 
 import Parametric.Syntax.Type as Type
 import Parametric.Syntax.Term as Term
+open import Base.Data.DependentList
 
 import Parametric.Syntax.MType as MType
 import Parametric.Syntax.MTerm as MTerm

--- a/Parametric/Denotation/CachingMValue.agda
+++ b/Parametric/Denotation/CachingMValue.agda
@@ -29,7 +29,7 @@ open import Level
 open import Function hiding (const)
 
 module Structure where
-  {-# NO_TERMINATION_CHECK #-}
+  {-# TERMINATING #-}
   ⟦_⟧ValTypeHidCache : (τ : ValType) → Set
   ⟦_⟧CompTypeHidCache : (τ : CompType) → Set
 

--- a/Parametric/Denotation/CachingMValue.agda
+++ b/Parametric/Denotation/CachingMValue.agda
@@ -14,6 +14,7 @@ module Parametric.Denotation.CachingMValue
     (⟦_⟧Base : Value.Structure Base)
   where
 
+open import Base.Data.DependentList
 open import Base.Denotation.Notation
 
 open Type.Structure Base

--- a/Parametric/Denotation/Evaluation.agda
+++ b/Parametric/Denotation/Evaluation.agda
@@ -20,6 +20,7 @@ open Value.Structure Base ⟦_⟧Base
 
 open import Base.Denotation.Notation
 
+open import Base.Data.DependentList
 open import Relation.Binary.PropositionalEquality
 open import Theorem.CongApp
 open import Postulate.Extensionality

--- a/Parametric/Denotation/Evaluation.agda
+++ b/Parametric/Denotation/Evaluation.agda
@@ -59,13 +59,10 @@ module Structure (⟦_⟧Const : Structure) where
     (terms : Terms Γ₁ Σ) (ρ : ⟦ Γ₂ ⟧) →
     ⟦ weaken-terms Γ₁≼Γ₂ terms ⟧Terms ρ ≡ ⟦ terms ⟧Terms (⟦ Γ₁≼Γ₂ ⟧ ρ)
 
-  weaken-terms-sound = {!!}
-  -- This is irrelevant for the crash
-  -- weaken-terms-sound ∅ ρ = refl
-  -- weaken-terms-sound (t • terms) ρ =
-  --   cong₂ _•_ (weaken-sound t ρ) (weaken-terms-sound terms ρ)
+  weaken-terms-sound ∅ ρ = refl
+  weaken-terms-sound (t • terms) ρ =
+    cong₂ _•_ (weaken-sound t ρ) (weaken-terms-sound terms ρ)
 
-  -- Agda crashes here:
   weaken-sound {Γ₁≼Γ₂ = Γ₁≼Γ₂} (var x) ρ = weaken-var-sound Γ₁≼Γ₂ x ρ
   weaken-sound (app s t) ρ = weaken-sound s ρ ⟨$⟩ weaken-sound t ρ
   weaken-sound (abs t) ρ = ext (λ v → weaken-sound t (v • ρ))

--- a/Parametric/Denotation/Evaluation.agda
+++ b/Parametric/Denotation/Evaluation.agda
@@ -59,10 +59,13 @@ module Structure (⟦_⟧Const : Structure) where
     (terms : Terms Γ₁ Σ) (ρ : ⟦ Γ₂ ⟧) →
     ⟦ weaken-terms Γ₁≼Γ₂ terms ⟧Terms ρ ≡ ⟦ terms ⟧Terms (⟦ Γ₁≼Γ₂ ⟧ ρ)
 
-  weaken-terms-sound ∅ ρ = refl
-  weaken-terms-sound (t • terms) ρ =
-    cong₂ _•_ (weaken-sound t ρ) (weaken-terms-sound terms ρ)
+  weaken-terms-sound = {!!}
+  -- This is irrelevant for the crash
+  -- weaken-terms-sound ∅ ρ = refl
+  -- weaken-terms-sound (t • terms) ρ =
+  --   cong₂ _•_ (weaken-sound t ρ) (weaken-terms-sound terms ρ)
 
+  -- Agda crashes here:
   weaken-sound {Γ₁≼Γ₂ = Γ₁≼Γ₂} (var x) ρ = weaken-var-sound Γ₁≼Γ₂ x ρ
   weaken-sound (app s t) ρ = weaken-sound s ρ ⟨$⟩ weaken-sound t ρ
   weaken-sound (abs t) ρ = ext (λ v → weaken-sound t (v • ρ))

--- a/Parametric/Denotation/Evaluation.agda
+++ b/Parametric/Denotation/Evaluation.agda
@@ -47,9 +47,10 @@ module Structure (⟦_⟧Const : Structure) where
   -- so we do explicit pattern matching instead.
   ⟦ ∅ ⟧Terms ρ = ∅
   ⟦ s • terms ⟧Terms ρ = ⟦ s ⟧Term ρ • ⟦ terms ⟧Terms ρ
-  
-  meaningOfTerm : ∀ {Γ τ} → Meaning (Term Γ τ)
-  meaningOfTerm = meaning ⟦_⟧Term
+
+  instance
+    meaningOfTerm : ∀ {Γ τ} → Meaning (Term Γ τ)
+    meaningOfTerm = meaning ⟦_⟧Term
 
   weaken-sound : ∀ {Γ₁ Γ₂ τ} {Γ₁≼Γ₂ : Γ₁ ≼ Γ₂}
     (t : Term Γ₁ τ) (ρ : ⟦ Γ₂ ⟧) → ⟦ weaken Γ₁≼Γ₂ t ⟧ ρ ≡ ⟦ t ⟧ (⟦ Γ₁≼Γ₂ ⟧ ρ)

--- a/Parametric/Denotation/MEvaluation.agda
+++ b/Parametric/Denotation/MEvaluation.agda
@@ -29,6 +29,7 @@ open MType.Structure Base
 open MTerm.Structure Const ValConst CompConst cbnToCompConst cbvToCompConst
 open MValue.Structure Base ⟦_⟧Base
 
+open import Base.Data.DependentList
 open import Base.Denotation.Notation
 
 -- Extension Point: Evaluation of fully applied constants.

--- a/Parametric/Denotation/MValue.agda
+++ b/Parametric/Denotation/MValue.agda
@@ -37,12 +37,13 @@ module Structure where
   ⟦ F τ ⟧CompType = ⟦ τ ⟧ValType
   ⟦ σ ⇛ τ ⟧CompType = ⟦ σ ⟧ValType → ⟦ τ ⟧CompType
 
-  -- This means: Overload ⟦_⟧ to mean ⟦_⟧ValType.
-  meaningOfValType : Meaning ValType
-  meaningOfValType = meaning ⟦_⟧ValType
+  instance
+    -- This means: Overload ⟦_⟧ to mean ⟦_⟧ValType.
+    meaningOfValType : Meaning ValType
+    meaningOfValType = meaning ⟦_⟧ValType
 
-  meaningOfCompType : Meaning CompType
-  meaningOfCompType = meaning ⟦_⟧CompType
+    meaningOfCompType : Meaning CompType
+    meaningOfCompType = meaning ⟦_⟧CompType
 
   -- We also provide: Environments of values (but not of computations).
   open import Base.Denotation.Environment ValType ⟦_⟧ValType public

--- a/Parametric/Denotation/Value.agda
+++ b/Parametric/Denotation/Value.agda
@@ -24,9 +24,10 @@ module Structure (⟦_⟧Base : Structure) where
   ⟦ base ι ⟧Type = ⟦ ι ⟧Base
   ⟦ σ ⇒ τ ⟧Type = ⟦ σ ⟧Type → ⟦ τ ⟧Type
 
-  -- This means: Overload ⟦_⟧ to mean ⟦_⟧Type.
-  meaningOfType : Meaning Type
-  meaningOfType = meaning ⟦_⟧Type
+  instance
+    -- This means: Overload ⟦_⟧ to mean ⟦_⟧Type.
+    meaningOfType : Meaning Type
+    meaningOfType = meaning ⟦_⟧Type
 
   -- We also provide: Environments of such values.
   open import Base.Denotation.Environment Type ⟦_⟧Type public

--- a/Parametric/Syntax/MTerm.agda
+++ b/Parametric/Syntax/MTerm.agda
@@ -1,5 +1,6 @@
 import Parametric.Syntax.Type as Type
 import Parametric.Syntax.Term as Term
+open import Base.Data.DependentList
 import Parametric.Syntax.MType as MType
 
 module Parametric.Syntax.MTerm

--- a/Parametric/Syntax/MTerm.agda
+++ b/Parametric/Syntax/MTerm.agda
@@ -124,7 +124,7 @@ module
 
   -- To satisfy termination checking, we'd need to inline fromCBV and weaken: fromCBV needs to produce a term in a bigger context.
   -- But let's ignore that.
-  {-# NO_TERMINATION_CHECK #-}
+  {-# TERMINATING #-}
   fromCBV : ∀ {Γ τ} (t : Term Γ τ) → Comp (fromCBVCtx Γ) (cbvToCompType τ)
 
   cbvTermsToComps : ∀ {Γ Σ} → Terms Γ Σ → Comps (fromCBVCtx Γ) (fromCBVToCompList Σ)

--- a/Parametric/Syntax/Term.agda
+++ b/Parametric/Syntax/Term.agda
@@ -72,7 +72,11 @@ module Structure (Const : Structure) where
     (Γ : Context) :
     (τ : Type) → Set
 
-  open import Base.Data.DependentList public
+  --open import Base.Data.DependentList public -- No
+  --
+  -- Workaround https://github.com/agda/agda/issues/1985 by making this import
+  -- private; many clients will need to start importing this now.
+  open import Base.Data.DependentList
 
   -- (Terms Γ Σ) represents a list of terms with types from Σ
   -- with free variables bound in Γ.

--- a/Parametric/Syntax/Term.agda
+++ b/Parametric/Syntax/Term.agda
@@ -59,9 +59,6 @@ Structure : Set₁
 Structure = Context → Type → Set
 
 module Structure (Const : Structure) where
-  import Base.Data.DependentList as DependentList
-  open DependentList public using (∅ ; _•_)
-  open DependentList
 
   -- Declarations of Term and Terms to enable mutual recursion.
   --
@@ -74,6 +71,8 @@ module Structure (Const : Structure) where
   data Term
     (Γ : Context) :
     (τ : Type) → Set
+
+  open import Base.Data.DependentList public
 
   -- (Terms Γ Σ) represents a list of terms with types from Σ
   -- with free variables bound in Γ.

--- a/Parametric/Syntax/Term.agda
+++ b/Parametric/Syntax/Term.agda
@@ -252,7 +252,7 @@ module Structure (Const : Structure) where
     absVAux τs zero    = absN (reverse τs)
     -- (Support for varying arity does not work here, so {τ₁} must be bound in
     -- the right-hand side).
-    absVAux τs (suc n) = λ {τ₁} → absVAux (τ₁ ∷ τs) n
+    absVAux τs (suc n) {τ₁} = absVAux (τ₁ ∷ τs) n --λ {τ₁} → absVAux (τ₁ ∷ τs) n
 
     -- "Initialize" accumulator to the empty list.
     absV = absVAux []

--- a/Parametric/Syntax/Type.agda
+++ b/Parametric/Syntax/Type.agda
@@ -6,6 +6,8 @@
 
 module Parametric.Syntax.Type where
 
+open import Base.Data.DependentList
+
 -- This is a module in the Parametric.* hierarchy, so it defines
 -- an extension point for plugins. In this case, the plugin can
 -- choose the syntax for data types. We always provide a binding

--- a/Postulate/Bag-Nehemiah.agda
+++ b/Postulate/Bag-Nehemiah.agda
@@ -31,7 +31,8 @@ infixr 5 _++_
 -- negate = mapMultiplicities (λ z → - z)
 postulate negateBag : Bag → Bag
 postulate emptyBag : Bag
-postulate abelian-bag : IsAbelianGroup _≡_ _++_ emptyBag negateBag
+instance
+  postulate abelian-bag : IsAbelianGroup _≡_ _++_ emptyBag negateBag
 
 -- Naming convention follows Algebra.Morphism
 -- Homomorphic₁ : morphism preserves negation

--- a/Structure/Bag/Nehemiah.agda
+++ b/Structure/Bag/Nehemiah.agda
@@ -52,12 +52,13 @@ right-identity : ∀ {A : Set} {f : A → A → A} {z neg} →
 right-identity abelian = proj₂ (IsMonoid.identity
   (IsGroup.isMonoid (IsAbelianGroup.isGroup abelian)))
 
-abelian-int : IsAbelianGroup _≡_ _+_ (+ 0) (-_)
-abelian-int =
-  IsRing.+-isAbelianGroup
-  (IsCommutativeRing.isRing
-  (CommutativeRing.isCommutativeRing
-  ℤ-is-commutativeRing))
+instance
+  abelian-int : IsAbelianGroup _≡_ _+_ (+ 0) (-_)
+  abelian-int =
+    IsRing.+-isAbelianGroup
+    (IsCommutativeRing.isRing
+    (CommutativeRing.isCommutativeRing
+    ℤ-is-commutativeRing))
 commutative-int : (m n : ℤ) → m + n ≡ n + m
 commutative-int = commutative abelian-int
 associative-int : (k m n : ℤ) → (k + m) + n ≡ k + (m + n)

--- a/Structure/Bag/Nehemiah.agda
+++ b/Structure/Bag/Nehemiah.agda
@@ -52,7 +52,7 @@ right-identity : ∀ {A : Set} {f : A → A → A} {z neg} →
 right-identity abelian = proj₂ (IsMonoid.identity
   (IsGroup.isMonoid (IsAbelianGroup.isGroup abelian)))
 
-abelian-int : IsAbelianGroup _≡_ _+_ (+ 0) -_
+abelian-int : IsAbelianGroup _≡_ _+_ (+ 0) (-_)
 abelian-int =
   IsRing.+-isAbelianGroup
   (IsCommutativeRing.isRing

--- a/UNDEFINED.agda
+++ b/UNDEFINED.agda
@@ -2,11 +2,5 @@
 
 module UNDEFINED where
 
-open import Data.Unit.NonEta using (Hidden)
-open import Data.Unit.NonEta public using (reveal)
-
 postulate
-  -- If this postulate would produce a T, it could be used as instance argument, triggering many ambiguities.
-  -- This postulate is named in capitals because it introduces an inconsistency.
-  -- Hence, this must be used through `reveal UNDEFINED`.
-  UNDEFINED : ∀ {ℓ} → {T : Set ℓ} → Hidden T
+  UNDEFINED : ∀ {ℓ} → {T : Set ℓ} → T

--- a/UNDEFINED.agda
+++ b/UNDEFINED.agda
@@ -2,8 +2,8 @@
 
 module UNDEFINED where
 
-open import Data.Unit.Core using (Hidden)
-open import Data.Unit.Core public using (reveal)
+open import Data.Unit.NonEta using (Hidden)
+open import Data.Unit.NonEta public using (reveal)
 
 postulate
   -- If this postulate would produce a T, it could be used as instance argument, triggering many ambiguities.

--- a/agdaCheck.sh
+++ b/agdaCheck.sh
@@ -4,4 +4,4 @@ cd "$(dirname "$0")"
 
 . agdaConfParse.sh.inc
 
-stack exec --package Agda -- agda +RTS -s -RTS -i . -i ${AGDA_LIB} ${mainFile} "$@"
+stack exec --package Agda -- agda +RTS -s -RTS -i . ${mainFile} "$@"

--- a/agdaCheck.sh.conf.example
+++ b/agdaCheck.sh.conf.example
@@ -1,3 +1,0 @@
-# Uncomment the next line and make it point to the Agda standard library v0.8.
-
-#AGDA_LIB=/some/path/to/agda-lib-0.8/src

--- a/agdaConfParse.sh.inc
+++ b/agdaConfParse.sh.inc
@@ -1,20 +1,8 @@
 # Emacs, this is -*- sh -*-
-# Load local configuration, which should not be committed to the repository.
-# This is supposed to set AGDA_LIB.
-. agdaCheck.sh.conf
 
 # Name of *the* file to check
 
 mainFile=README.agda
-
-if [ -z "${AGDA_LIB}" ]; then
-  cat <<EOF
-To setup this script, copy agdaCheck.sh.conf.example to agdaCheck.sh.conf and
-edit it following the contained instructions. Please do not commit
-agdaCheck.sh.conf to the repository, since its content is intrinsically local.
-EOF
-  exit 1
-fi
 
 # Note for changers: using Markdown-style ` in output is convenient for readers,
 # but troublesome for us since ` must be escaped, otherwise the shell will

--- a/ilc.cabal
+++ b/ilc.cabal
@@ -7,6 +7,6 @@ description:     Helper program for ILC, adapted from the Agda standard library.
 executable GenerateEverythingIlc
   hs-source-dirs:   .
   main-is:          GenerateEverythingIlc.hs
-  build-depends:    base >= 4.2 && < 4.8,
+  build-depends:    base >= 4.2 && < 5,
                     filemanip == 0.3.*,
-                    filepath >= 1.1 && < 1.4
+                    filepath >= 1.1 && < 2

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,11 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- Agda-2.4.2.4
+- Agda-2.5.1
+- EdisonAPI-1.3
+- EdisonCore-1.3.1.1
+- monadplus-1.4.2
+- QuickCheck-2.8.2
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,19 +1,17 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.11
+resolver: lts-6.2
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
+- location:
+    git: https://github.com/agda/agda
+    commit: e3472d7c1441c0d6db66be9e094e9dbcb7c33735
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- Agda-2.5.1
-- EdisonAPI-1.3
-- EdisonCore-1.3.1.1
-- monadplus-1.4.2
-- QuickCheck-2.8.2
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-0.7
+resolver: lts-3.11
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,13 +9,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- Agda-2.4.0.2
-- STMonadTrans-0.3.3
-- boxes-0.1.4
-- data-hash-0.2.0.0
-- equivalence-0.2.5
-- geniplate-0.6.0.5
-- haskell-src-exts-1.15.0.1
+- Agda-2.4.2.4
 
 # Override default flag values for local packages and extra-deps
 flags: {}
@@ -23,7 +17,6 @@ flags: {}
 # Extra package databases containing global packages
 extra-package-dbs: []
 
-compiler: ghc-7.8.4
 # Control whether we use the GHC we find on the path
 # system-ghc: true
 


### PR DESCRIPTION
Finally, thanks to the partial fix to agda/agda#1985, I can port this codebase to newer Agda releases! I completed this porting today. I'm merging this while I can :-).