### PR TITLE
Reduce ambiguity in instance inference

### DIFF
--- a/Base/Change/Algebra.agda
+++ b/Base/Change/Algebra.agda
@@ -214,8 +214,8 @@ module GroupChanges
 
     open ≡-Reasoning
 
-    changeAlgebra : ChangeAlgebra A
-    changeAlgebra = record
+    changeAlgebraGroup : ChangeAlgebra A
+    changeAlgebraGroup = record
       { Change = const A
       ; update = _⊕_
       ; diff = _⊝_
@@ -294,9 +294,9 @@ module FunctionChanges
       -- so I just use the underlying implementations.
       funUpdateDiff : ∀ u v → funUpdate v (funDiff u v) ≡ u
       instance
-        changeAlgebra : ChangeAlgebra (A → B)
+        changeAlgebraFun : ChangeAlgebra (A → B)
 
-      changeAlgebra = record
+      changeAlgebraFun = record
         { Change = FunctionChange
           -- in the paper, update and diff below are in Def. 2.7
         ; update = funUpdate
@@ -359,6 +359,21 @@ module FunctionChanges
     DerivativeAsChange {df = df} IsDerivative-f-df = record { apply = df ; correct = Derivative-is-valid df IsDerivative-f-df }
     -- In Equivalence.agda, derivative-is-nil-alternative then proves that a derivative is also a nil change.
 
+-- Reexport a few members with A and B marked as implicit parameters. This
+-- matters especially for changeAlgebra, since otherwise it can't be used for
+-- instance search.
+module _
+    {a} {b} {A : Set a} {B : Set b} {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}}
+  where
+    open FunctionChanges A B {{CA}} {{CB}} public
+      using
+        ( changeAlgebraFun
+        ; apply
+        ; correct
+        ; incrementalization
+        ; DerivativeAsChange
+        ; FunctionChange
+        )
 
 -- List (== Environment) Changes
 -- =============================
@@ -397,9 +412,9 @@ module ListChanges
     update-diff-all (px′ ∷ pxs′) (px ∷ pxs) = cong₂ _∷_ (update-diff px′ px) (update-diff-all pxs′ pxs)
 
     instance
-      changeAlgebra : ChangeAlgebraFamily (All P)
+      changeAlgebraListChanges : ChangeAlgebraFamily (All P)
 
-    changeAlgebra = record
+    changeAlgebraListChanges = record
       { change-algebra = λ xs → record
         { Change = All′ Δ
         ; update = update-all

--- a/Base/Change/Algebra.agda
+++ b/Base/Change/Algebra.agda
@@ -36,12 +36,12 @@ open import Level
 -- and update-diff is specified in Def. 2.1e.
 
 record IsChangeAlgebra
-    {c} {d}
+    {c}
     {Carrier : Set c}
-    (Change : Carrier → Set d)
+    (Change : Carrier → Set c)
     (update : (v : Carrier) (dv : Change v) → Carrier)
     (diff : (u v : Carrier) → Change v)
-    (nil : (u : Carrier) → Change u) : Set (c ⊔ d) where
+    (nil : (u : Carrier) → Change u) : Set (c) where
   field
     update-diff : ∀ u v → update v (diff u v) ≡ u
     -- This corresponds to Lemma 2.3 from the paper.
@@ -54,10 +54,10 @@ record IsChangeAlgebra
   after : ∀ {v} → Change v → Carrier
   after {v} dv = update v dv
 
-record ChangeAlgebra {c} ℓ
-    (Carrier : Set c) : Set (c ⊔ suc ℓ) where
+record ChangeAlgebra {c}
+    (Carrier : Set c) : Set (suc c) where
   field
-    Change : Carrier → Set ℓ
+    Change : Carrier → Set c
     update : (v : Carrier) (dv : Change v) → Carrier
     diff : (u v : Carrier) → Change v
 
@@ -103,11 +103,12 @@ open ChangeAlgebra {{...}} public
 --
 -- The following definitions implement this idea formally.
 
-record ChangeAlgebraFamily {a p} ℓ {A : Set a} (P : A → Set p): Set (suc ℓ ⊔ p ⊔ a) where
+record ChangeAlgebraFamily {a p} {A : Set a} (P : A → Set p): Set (suc p ⊔ a) where
   constructor
     family
   field
-    change-algebra : ∀ x → ChangeAlgebra ℓ (P x)
+    change-algebra : ∀ x → ChangeAlgebra (P x)
+
   module _ x where
     open ChangeAlgebra (change-algebra x) public
 
@@ -144,38 +145,38 @@ syntax diff′ x u v = u ⊟₍ x ₎ v
 --
 -- This corresponds to Def. 2.4 in the paper.
 
-RawChange : ∀ {a b c d} {A : Set a} {B : Set b} →
-  {{CA : ChangeAlgebra c A}} →
-  {{CB : ChangeAlgebra d B}} →
+RawChange : ∀ {a b} {A : Set a} {B : Set b} →
+  {{CA : ChangeAlgebra A}} →
+  {{CB : ChangeAlgebra B}} →
   (f : A → B) →
-  Set (a ⊔ c ⊔ d)
+  Set (a ⊔ b)
 RawChange f = ∀ a (da : Δ a) → Δ (f a)
 
-IsDerivative : ∀ {a b c d} {A : Set a} {B : Set b} →
-  {{CA : ChangeAlgebra c A}} →
-  {{CB : ChangeAlgebra d B}} →
+IsDerivative : ∀ {a b} {A : Set a} {B : Set b} →
+  {{CA : ChangeAlgebra A}} →
+  {{CB : ChangeAlgebra B}} →
   (f : A → B) →
   (df : RawChange f) →
-  Set (a ⊔ b ⊔ c)
+  Set (a ⊔ b)
 IsDerivative f df = ∀ a da → f a ⊞ df a da ≡ f (a ⊞ da)
 
 -- This is a variant of IsDerivative for change algebra families.
-RawChange₍_,_₎ : ∀ {a b p q c d} {A : Set a} {B : Set b} {P : A → Set p} {Q : B → Set q} →
-  {{CP : ChangeAlgebraFamily c P}} →
-  {{CQ : ChangeAlgebraFamily d Q}} →
+RawChange₍_,_₎ : ∀ {a b p q} {A : Set a} {B : Set b} {P : A → Set p} {Q : B → Set q} →
+  {{CP : ChangeAlgebraFamily P}} →
+  {{CQ : ChangeAlgebraFamily Q}} →
   (x : A) →
   (y : B) →
-  (f : P x → Q y) → Set (c ⊔ d ⊔ p)
+  (f : P x → Q y) → Set (p ⊔ q)
 RawChange₍_,_₎ x y f = ∀ px (dpx : Δ₍_₎ x px) → Δ₍_₎ y (f px)
 
-IsDerivative₍_,_₎ : ∀ {a b p q c d} {A : Set a} {B : Set b} {P : A → Set p} {Q : B → Set q} →
-  {{CP : ChangeAlgebraFamily c P}} →
-  {{CQ : ChangeAlgebraFamily d Q}} →
+IsDerivative₍_,_₎ : ∀ {a b p q} {A : Set a} {B : Set b} {P : A → Set p} {Q : B → Set q} →
+  {{CP : ChangeAlgebraFamily P}} →
+  {{CQ : ChangeAlgebraFamily Q}} →
   (x : A) →
   (y : B) →
   (f : P x → Q y) →
   (df : RawChange₍_,_₎ x y f) →
-  Set (p ⊔ q ⊔ c)
+  Set (p ⊔ q)
 IsDerivative₍_,_₎ {P = P} {{CP}} {{CQ}} x y f df = IsDerivative {{change-algebra₍ _ ₎}} {{change-algebra₍ _ ₎}} f df where
   CPx = change-algebra₍_₎ {{CP}} x
   CQy = change-algebra₍_₎ {{CQ}} y
@@ -213,7 +214,7 @@ module GroupChanges
 
     open ≡-Reasoning
 
-    changeAlgebra : ChangeAlgebra a A
+    changeAlgebra : ChangeAlgebra A
     changeAlgebra = record
       { Change = const A
       ; update = _⊕_
@@ -248,10 +249,10 @@ module GroupChanges
 -- are by equational reasoning using 2.1e for A and B.
 
 module FunctionChanges
-    {a} {b} {c} {d} (A : Set a) (B : Set b) {{CA : ChangeAlgebra c A}} {{CB : ChangeAlgebra d B}}
+    {a} {b} (A : Set a) (B : Set b) {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}}
   where
     -- This corresponds to Definition 2.6 in the paper.
-    record FunctionChange (f : A → B) : Set (a ⊔ b ⊔ c ⊔ d) where
+    record FunctionChange (f : A → B) : Set (a ⊔ b) where
       field
         -- Definition 2.6a
         apply : RawChange f
@@ -273,14 +274,14 @@ module FunctionChanges
           -- have to prove for Theorem 2.7.
         ; correct = λ a da →
           begin
-            _⊞_ {{CB}} (f (_⊞_ {{CA}} a da)) (g (_⊞_ {{CA}} (a ⊞ da) (nil (a ⊞ da))) ⊟ f (a ⊞ da))
-          ≡⟨ cong (λ □ → _⊞_ {{CB}} (f (a ⊞ da)) (g □ ⊟ f (a ⊞ da)))
-               (update-nil {{CA}} (a ⊞ da)) ⟩
-            _⊞_ {{CB}} (f (a ⊞ da)) (g (a ⊞ da) ⊟ f (a ⊞ da))
-          ≡⟨ update-diff {{CB}} (g (a ⊞ da)) (f (a ⊞ da)) ⟩
+            f (a ⊞ da) ⊞ (g (a ⊞ da ⊞ nil (a ⊞ da)) ⊟ f (a ⊞ da))
+          ≡⟨ cong (λ □ → f (a ⊞ da) ⊞ (g □ ⊟ f (a ⊞ da)))
+               (update-nil (a ⊞ da)) ⟩
+            f (a ⊞ da) ⊞ (g (a ⊞ da) ⊟ f (a ⊞ da))
+          ≡⟨ update-diff (g (a ⊞ da)) (f (a ⊞ da)) ⟩
             g (a ⊞ da)
-          ≡⟨ sym (update-diff {{CB}} (g (a ⊞ da)) (f a)) ⟩
-            _⊞_ {{CB}} (f a) (g (a ⊞ da) ⊟ f a)
+          ≡⟨ sym (update-diff (g (a ⊞ da)) (f a)) ⟩
+            f a ⊞ (g (a ⊞ da) ⊟ f a)
           ∎
         }
 
@@ -293,7 +294,7 @@ module FunctionChanges
       -- so I just use the underlying implementations.
       funUpdateDiff : ∀ u v → funUpdate v (funDiff u v) ≡ u
       instance
-        changeAlgebra : ChangeAlgebra (a ⊔ b ⊔ c ⊔ d) (A → B)
+        changeAlgebra : ChangeAlgebra (A → B)
 
       changeAlgebra = record
         { Change = FunctionChange
@@ -311,10 +312,10 @@ module FunctionChanges
       -- XXX remove mutual recursion by inlining the algebra in here?
       funUpdateDiff = λ g f → ext (λ a →
         begin
-          _⊞_ {{CB}} (f a) (g (_⊞_ {{CA}} a (nil a)) ⊟ f a)
-        ≡⟨ cong (λ □ → _⊞_ {{CB}} (f a) (g □ ⊟ f a)) (update-nil {{CA}} a) ⟩
-          _⊞_ {{CB}} (f a) (g a ⊟ f a)
-        ≡⟨ update-diff {{CB}}  (g a) (f a) ⟩
+          f a ⊞ (g (a ⊞ (nil a)) ⊟ f a)
+        ≡⟨ cong (λ □ → f a ⊞ (g □ ⊟ f a)) (update-nil a) ⟩
+          f a ⊞ (g a ⊟ f a)
+        ≡⟨ update-diff  (g a) (f a) ⟩
           g a
         ∎)
 
@@ -333,9 +334,9 @@ module FunctionChanges
       begin
         f a ⊞ apply (nil f) a da
       ≡⟨ sym (incrementalization f (nil f) a da) ⟩
-        (f ⊞ nil {{changeAlgebra}} f) (a ⊞ da)
+        (f ⊞ nil f) (a ⊞ da)
       ≡⟨ cong (λ □ → □ (a ⊞ da))
-           (update-nil {{changeAlgebra}} f) ⟩
+           (update-nil f) ⟩
         f (a ⊞ da)
       ∎
 
@@ -381,26 +382,26 @@ data All′ {a p q} {A : Set a}
     _∷_ : ∀ {x xs} {px : P x} {pxs : All P xs} (qx : Q px) (qxs : All′ Q pxs) → All′ Q (px ∷ pxs)
 
 module ListChanges
-    {a} {c} {A : Set a} (P : A → Set) {{C : ChangeAlgebraFamily c P}}
+    {a} {A : Set a} (P : A → Set) {{C : ChangeAlgebraFamily P}}
   where
-    update-all : ∀ {xs} → (pxs : All P xs) →  All′ (Δ₍_₎ {{C}} _) pxs  → All P xs
+    update-all : ∀ {xs} → (pxs : All P xs) → All′ Δ pxs  → All P xs
     update-all {[]} [] [] = []
-    update-all {x ∷ xs} (px ∷ pxs) (dpx ∷ dpxs) = (px ⊞₍ x ₎ dpx) ∷ update-all pxs dpxs
+    update-all {x ∷ xs} (px ∷ pxs) (dpx ∷ dpxs) = (px ⊞ dpx) ∷ update-all pxs dpxs
 
-    diff-all : ∀ {xs} → (pxs′ pxs : All P xs) → All′ (Δ₍_₎ {{C}} _) pxs
+    diff-all : ∀ {xs} → (pxs′ pxs : All P xs) → All′ Δ pxs
     diff-all [] [] = []
-    diff-all (px′ ∷ pxs′) (px ∷ pxs) = (px′ ⊟₍ _ ₎ px) ∷ diff-all pxs′ pxs
+    diff-all (px′ ∷ pxs′) (px ∷ pxs) = (px′ ⊟ px) ∷ diff-all pxs′ pxs
 
     update-diff-all : ∀ {xs} → (pxs′ pxs : All P xs) → update-all pxs (diff-all pxs′ pxs) ≡ pxs′
     update-diff-all [] [] = refl
-    update-diff-all (px′ ∷ pxs′) (px ∷ pxs) = cong₂ _∷_ (update-diff₍_₎ {{C}} _ px′ px) (update-diff-all pxs′ pxs)
+    update-diff-all (px′ ∷ pxs′) (px ∷ pxs) = cong₂ _∷_ (update-diff px′ px) (update-diff-all pxs′ pxs)
 
     instance
-      changeAlgebra : ChangeAlgebraFamily (c ⊔ a) (All P)
+      changeAlgebra : ChangeAlgebraFamily (All P)
 
     changeAlgebra = record
       { change-algebra = λ xs → record
-        { Change = All′ (Δ₍_₎ {{C}} _)
+        { Change = All′ Δ
         ; update = update-all
         ; diff = diff-all
         ; nil = λ xs → diff-all xs xs

--- a/Base/Change/Equivalence.agda
+++ b/Base/Change/Equivalence.agda
@@ -14,37 +14,37 @@ open import Function
 open import Base.Change.Equivalence.Base public
 open import Base.Change.Equivalence.EqReasoning public
 
-module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
+module _ {a} {A : Set a} {{ca : ChangeAlgebra A}} {x : A} where
   -- By update-nil, if dx = nil x, then x ⊞ dx ≡ x.
   -- As a consequence, if dx ≙ nil x, then x ⊞ dx ≡ x
-  nil-is-⊞-unit : ∀ (dx : Δ {{ca}} x) → dx ≙ nil x → x ⊞ dx ≡ x
+  nil-is-⊞-unit : ∀ (dx : Δ x) → dx ≙ nil x → x ⊞ dx ≡ x
   nil-is-⊞-unit dx dx≙nil-x =
     begin
       x ⊞ dx
     ≡⟨ proof dx≙nil-x ⟩
-      x ⊞ (nil {{ca}} x)
-    ≡⟨ update-nil {{ca}} x ⟩
+      x ⊞ (nil x)
+    ≡⟨ update-nil x ⟩
       x
     ∎
     where
       open ≡-Reasoning
 
   -- Here we prove the inverse:
-  ⊞-unit-is-nil : ∀ (dx : Δ {{ca}} x) → x ⊞ dx ≡ x → _≙_ {{ca}} dx (nil {{ca}} x)
+  ⊞-unit-is-nil : ∀ (dx : Δ x) → x ⊞ dx ≡ x → dx ≙ (nil x)
   ⊞-unit-is-nil dx x⊞dx≡x = doe $
     begin
       x ⊞ dx
     ≡⟨ x⊞dx≡x ⟩
       x
-    ≡⟨ sym (update-nil {{ca}} x) ⟩
-      x ⊞ nil {{ca}} x
+    ≡⟨ sym (update-nil x) ⟩
+      x ⊞ nil x
     ∎
     where
       open ≡-Reasoning
 
   -- Let's show that nil x is d.o.e. to x ⊟ x
   nil-x-is-x⊟x : nil x ≙ x ⊟ x
-  nil-x-is-x⊟x = ≙-sym (⊞-unit-is-nil (x ⊟ x) (update-diff {{ca}} x x))
+  nil-x-is-x⊟x = ≙-sym (⊞-unit-is-nil (x ⊟ x) (update-diff x x))
 
   -- TODO: we want to show that all functions of interest respect
   -- delta-observational equivalence, so that two d.o.e. changes can be
@@ -67,31 +67,31 @@ module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
   -- equivalence.
 
   -- This results pairs with update-diff.
-  diff-update : ∀ {dx : Δ {{ca}} x} → (x ⊞ dx) ⊟ x ≙ dx
+  diff-update : ∀ {dx : Δ x} → (x ⊞ dx) ⊟ x ≙ dx
   diff-update {dx} = doe lemma
     where
-      lemma : _⊞_ {{ca}} x (x ⊞ dx ⊟ x) ≡ x ⊞ dx
-      lemma = update-diff {{ca}} (x ⊞ dx) x
+      lemma : x ⊞ (x ⊞ dx ⊟ x) ≡ x ⊞ dx
+      lemma = update-diff (x ⊞ dx) x
 
   -- \begin{lemma}[Equivalence cancellation]
   --   |v2 `ominus` v1 `doe` dv| holds if and only if |v2 = v1 `oplus`
   --   dv|, for any |v1, v2 `elem` V| and |dv `elem` Dt ^ v1|.
   -- \end{lemma}
 
-  equiv-cancel-1 : ∀ x' dx → _≙_ {{ca}} (x' ⊟ x) dx → x' ≡ x ⊞ dx
+  equiv-cancel-1 : ∀ x' dx → (x' ⊟ x) ≙ dx → x' ≡ x ⊞ dx
   equiv-cancel-1 x' dx (doe x'⊟x≙dx) = trans (sym (update-diff x' x)) x'⊟x≙dx
-  equiv-cancel-2 : ∀ x' dx → x' ≡ x ⊞ dx → _≙_ {{ca}} (x' ⊟ x) dx
+  equiv-cancel-2 : ∀ x' dx → x' ≡ x ⊞ dx → x' ⊟ x ≙ dx
   equiv-cancel-2 _ dx refl = diff-update
 
-module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
-  {{CA : ChangeAlgebra c A}} {{CB : ChangeAlgebra d B}} where
+module _ {a} {b} {A : Set a} {B : Set b}
+  {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}} where
 
-  module FC = FunctionChanges A B {{CA}} {{CB}}
+  module FC = FunctionChanges A B
   open FC using (changeAlgebra; incrementalization; DerivativeAsChange)
   open FC.FunctionChange
 
-  equiv-fun-changes-respect : ∀ {x : A} {dx₁ dx₂ : Δ x} {f : A → B} {df₁ df₂} →
-    _≙_ {{changeAlgebra}} df₁ df₂ → dx₁ ≙ dx₂ → apply df₁ x dx₁ ≙ apply df₂ x dx₂
+  equiv-fun-changes-respect : ∀ {x : A} {dx₁ dx₂ : Δ x} {f : A → B} {df₁ df₂ : Δ f} →
+    _≙_ {x = f} df₁ df₂ → dx₁ ≙ dx₂ → apply df₁ x dx₁ ≙ apply df₂ x dx₂
   equiv-fun-changes-respect {x} {dx₁} {dx₂} {f} {df₁} {df₂} df₁≙df₂ dx₁≙dx₂ = doe lemma
     where
       open ≡-Reasoning
@@ -112,18 +112,18 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
           f x ⊞ apply df₂ x dx₂
         ∎
 
-  fun-change-respects : ∀ {x : A} {dx₁ dx₂ : Δ x} {f : A → B} (df : Δ f) →
+  fun-change-respects : ∀ {x : A} {dx₁ dx₂} {f : A → B} (df : Δ f) →
     dx₁ ≙ dx₂ → apply df x dx₁ ≙ apply df x dx₂
   fun-change-respects df dx₁≙dx₂ = equiv-fun-changes-respect (≙-refl {dx = df}) dx₁≙dx₂
 
   -- D.o.e. function changes behave like the same function (up to d.o.e.).
-  equiv-fun-changes-funs : ∀ {x : A} {dx : Δ x} {f : A → B} {df₁ df₂ : Δ f} →
-    _≙_ {{changeAlgebra}} df₁ df₂ → apply df₁ x dx ≙ apply df₂ x dx
+  equiv-fun-changes-funs : ∀ {x : A} {dx} {f : A → B} {df₁ df₂} →
+    _≙_ {x = f} df₁ df₂ → apply df₁ x dx ≙ apply df₂ x dx
   equiv-fun-changes-funs {dx = dx} df₁≙df₂ = equiv-fun-changes-respect df₁≙df₂ (≙-refl {dx = dx})
 
   derivative-doe-characterization : ∀ {a : A} {da : Δ a}
     {f : A → B} {df : RawChange f} (is-derivative : IsDerivative f df) →
-    _≙_ {{CB}} (df a da) (f (a ⊞ da) ⊟ f a)
+    df a da ≙ f (a ⊞ da) ⊟ f a
   derivative-doe-characterization {a} {da} {f} {df} is-derivative = doe lemma
     where
       open ≡-Reasoning
@@ -139,7 +139,7 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
 
   derivative-respects-doe : ∀ {x : A} {dx₁ dx₂ : Δ x}
     {f : A → B} {df : RawChange f} (is-derivative : IsDerivative f df) →
-    _≙_ {{CA}} dx₁ dx₂ →  _≙_ {{CB}} (df x dx₁) (df x dx₂)
+    dx₁ ≙ dx₂ → df x dx₁ ≙ df x dx₂
   derivative-respects-doe {x} {dx₁} {dx₂} {f} {df} is-derivative dx₁≙dx₂ =
     begin
       df x dx₁
@@ -156,7 +156,7 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
   -- This is also a corollary of fun-changes-respect
   derivative-respects-doe-alt : ∀ {x : A} {dx₁ dx₂ : Δ x}
     {f : A → B} {df : RawChange f} (is-derivative : IsDerivative f df) →
-    _≙_ {{CA}} dx₁ dx₂ →  _≙_ {{CB}} (df x dx₁) (df x dx₂)
+    dx₁ ≙ dx₂ → df x dx₁ ≙ df x dx₂
   derivative-respects-doe-alt {x} {dx₁} {dx₂} {f} {df} is-derivative dx₁≙dx₂ =
     fun-change-respects (DerivativeAsChange is-derivative) dx₁≙dx₂
 
@@ -180,7 +180,7 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
   -- that's a stronger hypothesis, which doesn't give you extra guarantees. But
   -- here's the statement and proof, for completeness:
 
-  delta-ext₂ : ∀ {f : A → B} → ∀ {df dg : Δ f} → (∀ x dx₁ dx₂ → _≙_ {{CA}} dx₁ dx₂ → apply df x dx₁ ≙ apply dg x dx₂) → df ≙ dg
+  delta-ext₂ : ∀ {f : A → B} → ∀ {df dg : Δ f} → (∀ x (dx₁ dx₂ : Δ x) → _≙_ {x = x} dx₁ dx₂ → apply df x dx₁ ≙ apply dg x dx₂) → df ≙ dg
   delta-ext₂ {f} {df} {dg} df-x-dx≙dg-x-dx = delta-ext (λ x dx → df-x-dx≙dg-x-dx x dx dx ≙-refl)
 
   -- We know that IsDerivative f (apply (nil f)) (by nil-is-derivative).
@@ -195,8 +195,8 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
     ≡⟨⟩
       (λ x → f x ⊞ apply df x (nil x))
     ≡⟨ ext (λ x → fdf x (nil x)) ⟩
-      (λ x → f (x ⊞ nil {{CA}} x))
-    ≡⟨ ext (λ x → cong f (update-nil {{CA}} x)) ⟩
+      (λ x → f (x ⊞ nil x))
+    ≡⟨ ext (λ x → cong f (update-nil x)) ⟩
       (λ x → f x)
     ≡⟨⟩
       f
@@ -220,7 +220,7 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
       f a ⊞ apply (nil f) a da
     ≡⟨ sym (incrementalization f (nil f) a da) ⟩
       (f ⊞ nil f) (a ⊞ da)
-    ≡⟨ cong (λ □ → □ (_⊞_ a da)) (update-nil f) ⟩
+    ≡⟨ cong (λ □ → □ (a ⊞ da)) (update-nil f) ⟩
       f (a ⊞ da)
     ∎
     where
@@ -239,13 +239,13 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
     where
       open ≙-Reasoning
 
-  equiv-derivative-is-derivative : ∀ {f : A → B} (df₁ df₂ : Δ f) → IsDerivative f (apply df₁) →  _≙_ {{changeAlgebra}} df₁ df₂ → IsDerivative f (apply df₂)
+  equiv-derivative-is-derivative : ∀ {f : A → B} df₁ df₂ → IsDerivative f (apply df₁) →  _≙_ {x = f} df₁ df₂ → IsDerivative f (apply df₂)
   equiv-derivative-is-derivative {f} df₁ df₂ IsDerivative-f-df₁ df₁≙df₂ a da =
     begin
       f a ⊞ apply df₂ a da
     ≡⟨ sym (incrementalization f df₂ a da) ⟩
       (f ⊞ df₂) (a ⊞ da)
-    ≡⟨ cong (λ □ → □ (_⊞_ a da)) lemma ⟩
+    ≡⟨ cong (λ □ → □ (a ⊞ da)) lemma ⟩
       f (a ⊞ da)
     ∎
     where
@@ -264,18 +264,18 @@ module _ {a} {b} {c} {d} {A : Set a} {B : Set b}
   -- (incorrectly) normal equality instead of delta-observational equivalence.
   deriv-zero :
     ∀ (f : A → B) df → IsDerivative f df →
-    ∀ v → df v (nil {{CA}} v) ≙ nil {{CB}} (f v)
+    ∀ v → df v (nil v) ≙ nil (f v)
   deriv-zero f df proof v = doe lemma
     where
       open ≡-Reasoning
-      lemma : f v ⊞ df v (nil v) ≡ f v ⊞ nil {{CB}} (f v)
+      lemma : f v ⊞ df v (nil v) ≡ f v ⊞ nil (f v)
       lemma =
         begin
-          f v ⊞ df v (nil {{CA}} v)
-        ≡⟨ proof v (nil {{CA}} v) ⟩
-          f (v ⊞ (nil {{CA}} v))
-        ≡⟨ cong f (update-nil {{CA}} v) ⟩
+          f v ⊞ df v (nil v)
+        ≡⟨ proof v (nil v) ⟩
+          f (v ⊞ (nil v))
+        ≡⟨ cong f (update-nil v) ⟩
           f v
-        ≡⟨ sym (update-nil {{CB}} (f v)) ⟩
-          f v ⊞ nil {{CB}} (f v)
+        ≡⟨ sym (update-nil (f v)) ⟩
+          f v ⊞ nil (f v)
         ∎

--- a/Base/Change/Equivalence.agda
+++ b/Base/Change/Equivalence.agda
@@ -86,10 +86,6 @@ module _ {a} {A : Set a} {{ca : ChangeAlgebra A}} {x : A} where
 module _ {a} {b} {A : Set a} {B : Set b}
   {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}} where
 
-  module FC = FunctionChanges A B
-  open FC using (changeAlgebra; incrementalization; DerivativeAsChange)
-  open FC.FunctionChange
-
   equiv-fun-changes-respect : ∀ {x : A} {dx₁ dx₂ : Δ x} {f : A → B} {df₁ df₂ : Δ f} →
     _≙_ {x = f} df₁ df₂ → dx₁ ≙ dx₂ → apply df₁ x dx₁ ≙ apply df₂ x dx₂
   equiv-fun-changes-respect {x} {dx₁} {dx₂} {f} {df₁} {df₂} df₁≙df₂ dx₁≙dx₂ = doe lemma

--- a/Base/Change/Equivalence.agda
+++ b/Base/Change/Equivalence.agda
@@ -87,7 +87,7 @@ module _ {a} {b} {A : Set a} {B : Set b}
   {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}} where
 
   equiv-fun-changes-respect : ∀ {x : A} {dx₁ dx₂ : Δ x} {f : A → B} {df₁ df₂ : Δ f} →
-    _≙_ {x = f} df₁ df₂ → dx₁ ≙ dx₂ → apply df₁ x dx₁ ≙ apply df₂ x dx₂
+    df₁ ≙₍ f ₎ df₂ → dx₁ ≙ dx₂ → apply df₁ x dx₁ ≙ apply df₂ x dx₂
   equiv-fun-changes-respect {x} {dx₁} {dx₂} {f} {df₁} {df₂} df₁≙df₂ dx₁≙dx₂ = doe lemma
     where
       open ≡-Reasoning
@@ -114,7 +114,7 @@ module _ {a} {b} {A : Set a} {B : Set b}
 
   -- D.o.e. function changes behave like the same function (up to d.o.e.).
   equiv-fun-changes-funs : ∀ {x : A} {dx} {f : A → B} {df₁ df₂} →
-    _≙_ {x = f} df₁ df₂ → apply df₁ x dx ≙ apply df₂ x dx
+    df₁ ≙₍ f ₎ df₂ → apply df₁ x dx ≙ apply df₂ x dx
   equiv-fun-changes-funs {dx = dx} df₁≙df₂ = equiv-fun-changes-respect df₁≙df₂ (≙-refl {dx = dx})
 
   derivative-doe-characterization : ∀ {a : A} {da : Δ a}
@@ -176,7 +176,7 @@ module _ {a} {b} {A : Set a} {B : Set b}
   -- that's a stronger hypothesis, which doesn't give you extra guarantees. But
   -- here's the statement and proof, for completeness:
 
-  delta-ext₂ : ∀ {f : A → B} → ∀ {df dg : Δ f} → (∀ x (dx₁ dx₂ : Δ x) → _≙_ {x = x} dx₁ dx₂ → apply df x dx₁ ≙ apply dg x dx₂) → df ≙ dg
+  delta-ext₂ : ∀ {f : A → B} → ∀ {df dg : Δ f} → (∀ x (dx₁ dx₂ : Δ x) → dx₁ ≙₍ x ₎ dx₂ → apply df x dx₁ ≙ apply dg x dx₂) → df ≙ dg
   delta-ext₂ {f} {df} {dg} df-x-dx≙dg-x-dx = delta-ext (λ x dx → df-x-dx≙dg-x-dx x dx dx ≙-refl)
 
   -- We know that IsDerivative f (apply (nil f)) (by nil-is-derivative).
@@ -235,7 +235,7 @@ module _ {a} {b} {A : Set a} {B : Set b}
     where
       open ≙-Reasoning
 
-  equiv-derivative-is-derivative : ∀ {f : A → B} df₁ df₂ → IsDerivative f (apply df₁) →  _≙_ {x = f} df₁ df₂ → IsDerivative f (apply df₂)
+  equiv-derivative-is-derivative : ∀ {f : A → B} df₁ df₂ → IsDerivative f (apply df₁) → df₁ ≙₍ f ₎ df₂ → IsDerivative f (apply df₂)
   equiv-derivative-is-derivative {f} df₁ df₂ IsDerivative-f-df₁ df₁≙df₂ a da =
     begin
       f a ⊞ apply df₂ a da

--- a/Base/Change/Equivalence/Base.agda
+++ b/Base/Change/Equivalence/Base.agda
@@ -58,3 +58,7 @@ module _ {a} {A : Set a} {{ca : ChangeAlgebra A}} {x : A} where
     ; _≈_           = _≙_
     ; isEquivalence = ≙-isEquivalence
     }
+
+≙-syntax : ∀ {a} {A : Set a} {{ca : ChangeAlgebra A}} (x : A) (dx₁ dx₂ : Δ x) → Set a
+≙-syntax x dx₁ dx₂ = _≙_ {x = x} dx₁ dx₂
+syntax ≙-syntax x dx₁ dx₂ = dx₁ ≙₍ x ₎ dx₂

--- a/Base/Change/Equivalence/Base.agda
+++ b/Base/Change/Equivalence/Base.agda
@@ -11,13 +11,13 @@ open import Level
 open import Data.Unit
 open import Function
 
-module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
+module _ {a} {A : Set a} {{ca : ChangeAlgebra A}} {x : A} where
   -- Delta-observational equivalence: these asserts that two changes
   -- give the same result when applied to a base value.
 
   -- To avoid unification problems, use a one-field record (a Haskell "newtype")
   -- instead of a "type synonym".
-  record _≙_ (dx dy : Δ {{ca}} x) : Set a where
+  record _≙_ (dx dy : Δ x) : Set a where
     -- doe = Delta-Observational Equivalence.
     constructor doe
     field
@@ -52,7 +52,7 @@ module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
     ; trans = ≙-trans
     }
 
-  ≙-setoid : Setoid ℓ a
+  ≙-setoid : Setoid a a
   ≙-setoid = record
     { Carrier       = Δ x
     ; _≈_           = _≙_

--- a/Base/Change/Equivalence/EqReasoning.agda
+++ b/Base/Change/Equivalence/EqReasoning.agda
@@ -13,12 +13,12 @@ open import Function
 
 open import Base.Change.Equivalence.Base public
 
-module _ {a ℓ} {A : Set a} {{ca : ChangeAlgebra ℓ A}} {x : A} where
+module _ {a} {A : Set a} {{ca : ChangeAlgebra A}} {x : A} where
   ------------------------------------------------------------------------
   -- Convenient syntax for equational reasoning
 
   import Relation.Binary.EqReasoning as EqR
 
   module ≙-Reasoning where
-    open EqR (≙-setoid {{ca}} {x = x}) public
+    open EqR (≙-setoid {x = x}) public
       renaming (_≈⟨_⟩_ to _≙⟨_⟩_)

--- a/Base/Change/Products.agda
+++ b/Base/Change/Products.agda
@@ -12,7 +12,7 @@ open import Data.Product
 
 -- Restriction: we pair sets on the same level (because right now everything
 -- else would risk getting in the way).
-module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}} where
+module ProductChanges ℓ {A B : Set ℓ} {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}} where
   open ≡-Reasoning
 
   -- The simplest possible definition of changes for products.
@@ -65,8 +65,8 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra A}} {{CB : Change
       ∎
 
   instance
-    changeAlgebra : ChangeAlgebra (A × B)
-    changeAlgebra = record
+    changeAlgebraProducts : ChangeAlgebra (A × B)
+    changeAlgebraProducts = record
       { Change = PChange
       ; update = _⊕_
       ; diff = _⊝_
@@ -106,10 +106,6 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra A}} {{CB : Change
 
   proj₂′Derivative : IsDerivative proj₂ proj₂′
   proj₂′Derivative v dv = refl
-
-  instance
-    B→A×B = FunctionChanges.changeAlgebra B (A × B)
-    A→B→A×B = FunctionChanges.changeAlgebra A (B → A × B)
 
   -- Morally, the following is a change:
   -- What one could wrongly expect to be the derivative of the constructor:
@@ -157,15 +153,6 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra A}} {{CB : Change
   uncurry₀ f (a , b) = f a b
 
   module _ {C : Set ℓ} {{CC : ChangeAlgebra C}} where
-    instance
-      B→C : ChangeAlgebra (B → C)
-      B→C = FunctionChanges.changeAlgebra B C
-      A→B→C : ChangeAlgebra (A → B → C)
-      A→B→C = FunctionChanges.changeAlgebra A (B → C)
-      A×B→C : ChangeAlgebra (A × B → C)
-      A×B→C = FunctionChanges.changeAlgebra (A × B) C
-    open FunctionChanges using (apply; correct)
-
     uncurry₀′-realizer : (f : A → B → C) → Δ f → (p : A × B) → Δ p → Δ (uncurry₀ f p)
     uncurry₀′-realizer f df (a , b) (da , db) = apply (apply df a da) b db
 

--- a/Base/Change/Products.agda
+++ b/Base/Change/Products.agda
@@ -12,7 +12,7 @@ open import Data.Product
 
 -- Restriction: we pair sets on the same level (because right now everything
 -- else would risk getting in the way).
-module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : ChangeAlgebra ℓ B}} where
+module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra A}} {{CB : ChangeAlgebra B}} where
   open ≡-Reasoning
 
   -- The simplest possible definition of changes for products.
@@ -65,7 +65,7 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : Ch
       ∎
 
   instance
-    changeAlgebra : ChangeAlgebra ℓ (A × B)
+    changeAlgebra : ChangeAlgebra (A × B)
     changeAlgebra = record
       { Change = PChange
       ; update = _⊕_
@@ -108,8 +108,8 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : Ch
   proj₂′Derivative v dv = refl
 
   instance
-    B→A×B = FunctionChanges.changeAlgebra {c = ℓ} {d = ℓ} B (A × B) {{CB}} {{changeAlgebra}}
-    A→B→A×B = FunctionChanges.changeAlgebra {d = ℓ} A (B → A × B) {{CA}} {{B→A×B}}
+    B→A×B = FunctionChanges.changeAlgebra B (A × B)
+    A→B→A×B = FunctionChanges.changeAlgebra A (B → A × B)
 
   -- Morally, the following is a change:
   -- What one could wrongly expect to be the derivative of the constructor:
@@ -156,13 +156,13 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : Ch
   uncurry₀ : ∀ {C : Set ℓ} → (A → B → C) → A × B → C
   uncurry₀ f (a , b) = f a b
 
-  module _ {C : Set ℓ} {{CC : ChangeAlgebra ℓ C}} where
+  module _ {C : Set ℓ} {{CC : ChangeAlgebra C}} where
     instance
-      B→C : ChangeAlgebra ℓ (B → C)
+      B→C : ChangeAlgebra (B → C)
       B→C = FunctionChanges.changeAlgebra B C
-      A→B→C : ChangeAlgebra ℓ (A → B → C)
+      A→B→C : ChangeAlgebra (A → B → C)
       A→B→C = FunctionChanges.changeAlgebra A (B → C)
-      A×B→C : ChangeAlgebra ℓ (A × B → C)
+      A×B→C : ChangeAlgebra (A × B → C)
       A×B→C = FunctionChanges.changeAlgebra (A × B) C
     open FunctionChanges using (apply; correct)
 
@@ -229,11 +229,11 @@ module ProductChanges ℓ (A B : Set ℓ) {{CA : ChangeAlgebra ℓ A}} {{CB : Ch
       ; correct = uncurry₀′-realizer-correct f df }
 
     -- Now proving that uncurry₀′ is a derivative is trivial!
-    uncurry₀′Derivative₀ : IsDerivative {{CB = A×B→C}} uncurry₀ uncurry₀′
+    uncurry₀′Derivative₀ : IsDerivative uncurry₀ uncurry₀′
     uncurry₀′Derivative₀ f df = refl
 
     -- If you wonder what's going on, here's the step-by-step proof, going purely by definitional equality.
-    uncurry₀′Derivative : IsDerivative {{CB = A×B→C}} uncurry₀ uncurry₀′
+    uncurry₀′Derivative : IsDerivative uncurry₀ uncurry₀′
     uncurry₀′Derivative f df =
       begin
         uncurry₀ f ⊞ uncurry₀′ f df

--- a/Base/Change/Sums.agda
+++ b/Base/Change/Sums.agda
@@ -9,7 +9,7 @@ open import Base.Change.Algebra
 open import Base.Change.Equivalence
 open import Postulate.Extensionality
 
-module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra ℓ X}} {{CY : ChangeAlgebra ℓ Y}} where
+module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra X}} {{CY : ChangeAlgebra Y}} where
   open ≡-Reasoning
 
   -- This is an indexed datatype, so it has two constructors per argument. But
@@ -49,7 +49,7 @@ module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra ℓ X}} {{CY : Change
   s-update-nil (inj₂ y) = cong inj₂ (update-nil y)
 
   instance
-    changeAlgebra : ChangeAlgebra ℓ (X ⊎ Y)
+    changeAlgebra : ChangeAlgebra (X ⊎ Y)
     changeAlgebra = record
       { Change = SumChange
       ; update = _⊕_
@@ -79,7 +79,7 @@ module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra ℓ X}} {{CY : Change
   match f g (inj₁ x) = f x
   match f g (inj₂ y) = g y
 
-  module _ {Z : Set ℓ} {{CZ : ChangeAlgebra ℓ Z}} where
+  module _ {Z : Set ℓ} {{CZ : ChangeAlgebra Z}} where
     instance
       X→Z = FunctionChanges.changeAlgebra X Z {{CX}} {{CZ}}
       --module ΔX→Z = FunctionChanges X Z {{CX}} {{CZ}}

--- a/Base/Change/Sums.agda
+++ b/Base/Change/Sums.agda
@@ -9,7 +9,7 @@ open import Base.Change.Algebra
 open import Base.Change.Equivalence
 open import Postulate.Extensionality
 
-module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra X}} {{CY : ChangeAlgebra Y}} where
+module SumChanges ℓ {X Y : Set ℓ} {{CX : ChangeAlgebra X}} {{CY : ChangeAlgebra Y}} where
   open ≡-Reasoning
 
   -- This is an indexed datatype, so it has two constructors per argument. But
@@ -49,8 +49,8 @@ module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra X}} {{CY : ChangeAlge
   s-update-nil (inj₂ y) = cong inj₂ (update-nil y)
 
   instance
-    changeAlgebra : ChangeAlgebra (X ⊎ Y)
-    changeAlgebra = record
+    changeAlgebraSums : ChangeAlgebra (X ⊎ Y)
+    changeAlgebraSums = record
       { Change = SumChange
       ; update = _⊕_
       ; diff = _⊝_
@@ -80,16 +80,6 @@ module SumChanges ℓ (X Y : Set ℓ) {{CX : ChangeAlgebra X}} {{CY : ChangeAlge
   match f g (inj₂ y) = g y
 
   module _ {Z : Set ℓ} {{CZ : ChangeAlgebra Z}} where
-    instance
-      X→Z = FunctionChanges.changeAlgebra X Z {{CX}} {{CZ}}
-      --module ΔX→Z = FunctionChanges X Z {{CX}} {{CZ}}
-      Y→Z = FunctionChanges.changeAlgebra Y Z {{CY}} {{CZ}}
-      --module ΔY→Z = FunctionChanges Y Z {{CY}} {{CZ}}
-      X⊎Y→Z = FunctionChanges.changeAlgebra (X ⊎ Y) Z {{changeAlgebra}} {{CZ}}
-      Y→Z→X⊎Y→Z = FunctionChanges.changeAlgebra (Y → Z) (X ⊎ Y → Z) {{Y→Z}} {{X⊎Y→Z}}
-
-    open FunctionChanges using (apply; correct)
-
     match′₀-realizer : (f : X → Z) → Δ f → (g : Y → Z) → Δ g → (s : X ⊎ Y) → Δ s → Δ (match f g s)
     match′₀-realizer f df g dg (inj₁ x) (ch₁ dx) = apply df x dx
     match′₀-realizer f df g dg (inj₁ x) (rp₁₂ y) = ((g ⊞ dg) y) ⊟ (f x)

--- a/Nehemiah/Change/Correctness.agda
+++ b/Nehemiah/Change/Correctness.agda
@@ -38,9 +38,6 @@ import Parametric.Change.Correctness
 open import Algebra.Structures
 
 private
-  open import Level using () renaming (zero to lzero)
-  open FunctionChanges ℤ Bag using (FunctionChange; changeAlgebra)
-
   flatmap-funarg-equal : ∀ (f : ℤ → Bag) (Δf : Δ₍ int ⇒ bag ₎ f) Δf′ (Δf≈Δf′ : Δf ≈₍ int ⇒ bag ₎ Δf′) →
     (f ⊞₍ int ⇒ bag ₎ Δf) ≡ (f ⟦⊕₍ int ⇒ bag ₎⟧ Δf′)
   flatmap-funarg-equal f Δf Δf′ Δf≈Δf′ = ext lemma

--- a/Nehemiah/Change/Correctness.agda
+++ b/Nehemiah/Change/Correctness.agda
@@ -39,7 +39,7 @@ open import Algebra.Structures
 
 private
   open import Level using () renaming (zero to lzero)
-  open FunctionChanges {c = lzero} {d = lzero} ℤ Bag using (FunctionChange; changeAlgebra)
+  open FunctionChanges ℤ Bag using (FunctionChange; changeAlgebra)
 
   flatmap-funarg-equal : ∀ (f : ℤ → Bag) (Δf : Δ₍ int ⇒ bag ₎ f) Δf′ (Δf≈Δf′ : Δf ≈₍ int ⇒ bag ₎ Δf′) →
     (f ⊞₍ int ⇒ bag ₎ Δf) ≡ (f ⟦⊕₍ int ⇒ bag ₎⟧ Δf′)

--- a/Nehemiah/Change/Validity.agda
+++ b/Nehemiah/Change/Validity.agda
@@ -20,13 +20,12 @@ open import Base.Change.Algebra
 
 open import Level
 
-change-algebra-base : ∀ ι → ChangeAlgebra zero ⟦ ι ⟧Base
+change-algebra-base : ∀ ι → ChangeAlgebra ⟦ ι ⟧Base
 change-algebra-base base-int = GroupChanges.changeAlgebra ℤ {{abelian-int}}
 change-algebra-base base-bag = GroupChanges.changeAlgebra Bag {{abelian-bag}}
 
 instance
-  change-algebra-base-family : ChangeAlgebraFamily zero ⟦_⟧Base
+  change-algebra-base-family : ChangeAlgebraFamily ⟦_⟧Base
   change-algebra-base-family = family change-algebra-base
 
---open Validity.Structure {{change-algebra-base-family}} public --XXX agda/agda#1985.
-open Validity.Structure public
+open Validity.Structure {{change-algebra-base-family}} public

--- a/Nehemiah/Change/Validity.agda
+++ b/Nehemiah/Change/Validity.agda
@@ -21,8 +21,8 @@ open import Base.Change.Algebra
 open import Level
 
 change-algebra-base : ∀ ι → ChangeAlgebra ⟦ ι ⟧Base
-change-algebra-base base-int = GroupChanges.changeAlgebra ℤ {{abelian-int}}
-change-algebra-base base-bag = GroupChanges.changeAlgebra Bag {{abelian-bag}}
+change-algebra-base base-int = GroupChanges.changeAlgebraGroup _ {{abelian-int}}
+change-algebra-base base-bag = GroupChanges.changeAlgebraGroup _ {{abelian-bag}}
 
 instance
   change-algebra-base-family : ChangeAlgebraFamily ⟦_⟧Base

--- a/PLDI14-List-of-Theorems.agda
+++ b/PLDI14-List-of-Theorems.agda
@@ -41,13 +41,13 @@ open Base.Change.Algebra.FunctionChanges
 -- Definition 2.7 (Operations on function changes)
 -- ChangeAlgebra.update FunctionChanges.changeAlgebra
 -- ChangeAlgebra.diff   FunctionChanges.changeAlgebra
-open Base.Change.Algebra.FunctionChanges using (changeAlgebra)
+open Base.Change.Algebra.FunctionChanges using (changeAlgebraFun)
 
 -- Theorem 2.8 (Function changes form a change structure)
 -- (In Agda, the proof of Theorem 2.8 has to be included in the
 -- definition of function changes, here
 -- FunctionChanges.changeAlgebra.)
-open Base.Change.Algebra.FunctionChanges using (changeAlgebra)
+open Base.Change.Algebra.FunctionChanges using (changeAlgebraFun)
 
 -- Theorem 2.9 (Incrementalization)
 open Base.Change.Algebra.FunctionChanges using (incrementalization)

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -30,6 +30,7 @@ module Structure {{change-algebra-base : Structure}} where
   -- change algebras
 
   open CA public renaming
+    -- Constructors for All′
     ( [] to ∅
     ; _∷_ to _•_
     )
@@ -37,8 +38,8 @@ module Structure {{change-algebra-base : Structure}} where
   -- We provide: change algebra for every type
   instance
     change-algebra : ∀ τ → ChangeAlgebra ⟦ τ ⟧Type
-    change-algebra (base ι) = change-algebra₍_₎ {{change-algebra-base}} ι
-    change-algebra (τ₁ ⇒ τ₂) = CA.FunctionChanges.changeAlgebra _ _ {{change-algebra τ₁}} {{change-algebra τ₂}}
+    change-algebra (base ι) = change-algebra₍ ι ₎
+    change-algebra (τ₁ ⇒ τ₂) = changeAlgebraFun {{change-algebra τ₁}} {{change-algebra τ₂}}
 
     change-algebra-family : ChangeAlgebraFamily ⟦_⟧Type
     change-algebra-family = family change-algebra
@@ -46,7 +47,7 @@ module Structure {{change-algebra-base : Structure}} where
   -- function changes
 
   module _ {τ₁ τ₂ : Type} where
-    open FunctionChanges.FunctionChange {{change-algebra τ₁}} {{change-algebra τ₂}} public
+    open FunctionChange {{change-algebra τ₁}} {{change-algebra τ₂}} public
       renaming
         ( correct to is-valid
         ; apply to call-change
@@ -55,7 +56,7 @@ module Structure {{change-algebra-base : Structure}} where
   -- We also provide: change environments (aka. environment changes).
 
   open ListChanges ⟦_⟧Type {{change-algebra-family}} public using () renaming
-    ( changeAlgebra to environment-changes
+    ( changeAlgebraListChanges to environment-changes
     )
 
   after-env : ∀ {Γ : Context} → {ρ : ⟦ Γ ⟧} (dρ : Δ₍ Γ ₎ ρ) → ⟦ Γ ⟧

--- a/Parametric/Change/Validity.agda
+++ b/Parametric/Change/Validity.agda
@@ -24,7 +24,7 @@ open import Level
 
 -- Extension Point: Change algebras for base types
 Structure : Set₁
-Structure = ChangeAlgebraFamily zero ⟦_⟧Base
+Structure = ChangeAlgebraFamily ⟦_⟧Base
 
 module Structure {{change-algebra-base : Structure}} where
   -- change algebras
@@ -36,11 +36,11 @@ module Structure {{change-algebra-base : Structure}} where
 
   -- We provide: change algebra for every type
   instance
-    change-algebra : ∀ τ → ChangeAlgebra zero ⟦ τ ⟧Type
+    change-algebra : ∀ τ → ChangeAlgebra ⟦ τ ⟧Type
     change-algebra (base ι) = change-algebra₍_₎ {{change-algebra-base}} ι
     change-algebra (τ₁ ⇒ τ₂) = CA.FunctionChanges.changeAlgebra _ _ {{change-algebra τ₁}} {{change-algebra τ₂}}
 
-    change-algebra-family : ChangeAlgebraFamily zero ⟦_⟧Type
+    change-algebra-family : ChangeAlgebraFamily ⟦_⟧Type
     change-algebra-family = family change-algebra
 
   -- function changes


### PR DESCRIPTION
This branch builds on top of agda-2.5.2—a few things didn't work well with the previous snapshot and that was the occasion to do the upgrade.