### PR TITLE
Stop subscripting change composition with base value

### DIFF
--- a/Thesis/Changes.agda
+++ b/Thesis/Changes.agda
@@ -1,4 +1,3 @@
-{-# OPTIONS --allow-unsolved-metas #-}
 module Thesis.Changes where
 
 open import Data.Product
@@ -264,16 +263,18 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
   s⊝-fromto s1@(inj₂ b1) s2@(inj₁ a2) = sftrp s1 s2
 
   _s⊚2_ : SumChange2 → SumChange2 → SumChange2
-  _ s⊚2 rp s3 = rp s3
+  ds1 s⊚2 rp s3 = rp s3
   ch₁ da1 s⊚2 ch₁ da2 = ch₁ (da1 ⊚[ A ] da2)
   rp (inj₁ a2) s⊚2 ch₁ da2 = rp (inj₁ (a2 ⊕ da2))
   ch₂ db1 s⊚2 ch₂ db2 = ch₂ (db1 ⊚[ B ] db2)
   rp (inj₂ b2) s⊚2 ch₂ db2 = rp (inj₂ (b2 ⊕ db2))
   -- Cases for invalid combinations of input changes.
-  ch₂ db s⊚2 ch₁ da = {!!}
-  rp (inj₂ y) s⊚2 ch₁ da2 = {!!}
-  ch₁ da s⊚2 ch₂ db = {!!}
-  rp (inj₁ a2) s⊚2 ch₂ db2 = {!!}
+  --
+  -- That is, whenever ds2 is a non-replacement change for outputs that ds1
+  -- can't produce.
+  --
+  -- We can prove validity preservation *without* filling this in.
+  ds1 s⊚2 ds2 = ds1
 
   _s⊚_ : SumChange → SumChange → SumChange
   ds1 s⊚ ds2 = convert₁ (convert ds1 s⊚2 convert ds2)

--- a/Thesis/Changes.agda
+++ b/Thesis/Changes.agda
@@ -290,10 +290,14 @@ instance
   unitCS = record
     { Ch = ⊤
     ; ch_from_to_ = λ dv v1 v2 → ⊤
-    ; isCompChangeStructure = IsChangeStructure→IsCompChangeStructure (record
+    ; isCompChangeStructure = record
+      { isChangeStructure = record
       { _⊕_ = λ _ _ → tt
       ; fromto→⊕ = λ { _ _ tt _ → refl }
       ; _⊝_ = λ _ _ → tt
       ; ⊝-fromto = λ a b → tt
-      })
+      }
+      ; _⊚[_]_ = λ da1 a da2 → tt
+      ; ⊚-fromto = λ a1 a2 a3 da1 da2 daa1 daa2 → tt
+      }
     }

--- a/Thesis/Changes.agda
+++ b/Thesis/Changes.agda
@@ -251,16 +251,12 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
     -- sft = Sum From To
     sft₁ : ∀ {da a1 a2} (daa : ch da from a1 to a2) → sch (convert₁ (ch₁ da)) from (inj₁ a1) to (inj₁ a2)
     sft₂ : ∀ {db b1 b2} (dbb : ch db from b1 to b2) → sch (convert₁ (ch₂ db)) from (inj₂ b1) to (inj₂ b2)
-    sftrp₁ : ∀ a1 b2 → sch (convert₁ (rp (inj₂ b2))) from (inj₁ a1) to (inj₂ b2)
-    sftrp₂ : ∀ b1 a2 → sch (convert₁ (rp (inj₁ a2))) from (inj₂ b1) to (inj₁ a2)
     sftrp : ∀ s1 s2 → sch (convert₁ (rp s2)) from s1 to s2
 
   sfromto→⊕2 : (ds : SumChange2) (s1 s2 : A ⊎ B) →
     sch convert₁ ds from s1 to s2 → s1 s⊕2 ds ≡ s2
   sfromto→⊕2 (ch₁ da) (inj₁ a1) (inj₁ a2) (sft₁ daa) = cong inj₁ (fromto→⊕ _ _ _ daa)
   sfromto→⊕2 (ch₂ db) (inj₂ b1) (inj₂ b2) (sft₂ dbb) = cong inj₂ (fromto→⊕ _ _ _ dbb)
-  sfromto→⊕2 (rp .(inj₂ y)) (inj₁ x) (inj₂ y) (sftrp₁ .x .y) = refl
-  sfromto→⊕2 (rp .(inj₁ x)) (inj₂ y) (inj₁ x) (sftrp₂ .y .x) = refl
   sfromto→⊕2 (rp .s2) .s1 .s2 (sftrp s1 s2) = refl
 
   sfromto→⊕ : (ds : SumChange) (s1 s2 : A ⊎ B) →
@@ -271,25 +267,23 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
         dss)
   s⊝-fromto : (s1 s2 : A ⊎ B) → sch s2 s⊝ s1 from s1 to s2
   s⊝-fromto (inj₁ a1) (inj₁ a2) = sft₁ (⊝-fromto a1 a2)
-  s⊝-fromto (inj₁ a1) (inj₂ b2) = sftrp₁ a1 b2
-  s⊝-fromto (inj₂ b1) (inj₁ a2) = sftrp₂ b1 a2
   s⊝-fromto (inj₂ b1) (inj₂ b2) = sft₂ (⊝-fromto b1 b2)
+  s⊝-fromto s1@(inj₁ a1) s2@(inj₂ b2) = sftrp s1 s2
+  s⊝-fromto s1@(inj₂ b1) s2@(inj₁ a2) = sftrp s1 s2
 
   -- TODO: drop all indexes prefixed with _
   _s⊚2[_]_ : SumChange2 → A ⊎ B → SumChange2 → SumChange2
+  _ s⊚2[ _s1 ] rp s3 = rp s3
   ch₁ da1 s⊚2[ inj₁ _a ] ch₁ da2 = ch₁ (da1 ⊚[ _a ] da2)
-  ch₁ da1 s⊚2[ inj₂ _b ] ch₁ da2 = {!!}
+  ch₁ da1 s⊚2[ inj₂ _b ] ch₁ da2 = ch₁ (da1 ⊚[ {!!} ] da2)
   ch₂ db s⊚2[ _s ] ch₁ da = {!!}
   rp (inj₁ a2) s⊚2[ _s ] ch₁ da2 = rp (inj₁ (a2 ⊕ da2))
   rp (inj₂ y) s⊚2[ _s ] ch₁ da2 = {!!}
   ch₁ da s⊚2[ _s ] ch₂ db = {!!}
-  ch₂ db1 s⊚2[ inj₁ _a ] ch₂ db2 = ch₂ {!!}
+  ch₂ db1 s⊚2[ inj₁ _a ] ch₂ db2 = ch₂ (db1 ⊚[ {!!} ] db2)
   ch₂ db1 s⊚2[ inj₂ _b ] ch₂ db2 = ch₂ (db1 ⊚[ _b ] db2)
   rp (inj₁ a2) s⊚2[ _s ] ch₂ db2 = {!!}
   rp (inj₂ b2) s⊚2[ _s ] ch₂ db2 = rp (inj₂ (b2 ⊕ db2))
-  ch₁ da s⊚2[ _s ] rp s₁ = rp s₁
-  ch₂ db s⊚2[ _s ] rp s₁ = rp s₁
-  rp s2 s⊚2[ _s1 ] rp s3 = rp s3
 
   _s⊚[_]_ : SumChange → A ⊎ B → SumChange → SumChange
   ds1 s⊚[ s ] ds2 = convert₁ (convert ds1 s⊚2[ s ] convert ds2)
@@ -297,18 +291,17 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
   s⊚-fromto : (s1 s2 s3 : A ⊎ B) (ds1 ds2 : SumChange) →
       sch ds1 from s1 to s2 →
       sch ds2 from s2 to s3 → sch ds1 s⊚[ s1 ] ds2 from s1 to s3
-  s⊚-fromto = {!!}
 
-  -- s⊚-fromto (inj₁ a1) (inj₁ a2) (inj₁ a3) (inj₁ (inj₁ da1)) (inj₁ (inj₁ da2)) (sft₁ daa1) (sft₁ daa2) = sft₁ (⊚-fromto a1 a2 a3 _ _ daa1 daa2)
-  -- s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ a3) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) with sfromto→⊕ (inj₁ (inj₁ da2)) _ _ (sft₁ daa2)
-  -- s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ .(a2 ⊕ da2)) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) | refl = sftrp₂ b1 (a2 ⊕ da2)
-  -- s⊚-fromto (inj₂ b1) (inj₂ b2) (inj₂ b3) (inj₁ (inj₂ db1)) (inj₁ (inj₂ db2)) (sft₂ dbb1) (sft₂ dbb2) = sft₂ (⊚-fromto b1 b2 b3 _ _ dbb1 dbb2)
-  -- s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ _) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) with sfromto→⊕ (inj₁ (inj₂ db2)) _ _ (sft₂ dbb2)
-  -- s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ (b2 ⊕ db2)) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) | refl = sftrp₁ a1 (b2 ⊕ db2)
-  -- s⊚-fromto (inj₁ a1) .(inj₁ a2) .(inj₂ b2) .(inj₁ (inj₁ _)) .(inj₂ (inj₂ b2)) (sft₁ daa) (sftrp₁ a2 b2) = sftrp₁ a1 b2
-  -- s⊚-fromto .(inj₂ b1) .(inj₁ a1) .(inj₂ b2) .(inj₂ (inj₁ a1)) .(inj₂ (inj₂ b2)) (sftrp₂ b1 .a1) (sftrp₁ a1 b2) = {!!}
-  -- s⊚-fromto .(inj₂ _) .(inj₂ b2) .(inj₁ a2) .(inj₁ (inj₂ _)) .(inj₂ (inj₁ a2)) (sft₂ dbb2) (sftrp₂ b2 a2) = sftrp₂ _ _
-  -- s⊚-fromto .(inj₁ a1) .(inj₂ b1) .(inj₁ a2) .(inj₂ (inj₂ b1)) .(inj₂ (inj₁ a2)) (sftrp₁ a1 .b1) (sftrp₂ b1 a2) = {!!}
+  s⊚-fromto (inj₁ a1) (inj₁ a2) (inj₁ a3) (inj₁ (inj₁ da1)) (inj₁ (inj₁ da2)) (sft₁ daa1) (sft₁ daa2) = sft₁ (⊚-fromto a1 a2 a3 _ _ daa1 daa2)
+  s⊚-fromto (inj₂ b1) (inj₂ b2) (inj₂ b3) (inj₁ (inj₂ db1)) (inj₁ (inj₂ db2)) (sft₂ dbb1) (sft₂ dbb2) = sft₂ (⊚-fromto b1 b2 b3 _ _ dbb1 dbb2)
+  s⊚-fromto s1 (inj₁ a2) (inj₁ a3) .(inj₂ (inj₁ _)) .(inj₁ (inj₁ _)) (sftrp .s1 .(inj₁ _)) (sft₁ daa) rewrite fromto→⊕ _ a2 a3 daa = sftrp _ _
+  s⊚-fromto s1 (inj₂ b2) (inj₂ b3) .(inj₂ (inj₂ _)) .(inj₁ (inj₂ _)) (sftrp .s1 .(inj₂ _)) (sft₂ dbb) rewrite fromto→⊕ _ b2 b3 dbb = sftrp _ _
+  s⊚-fromto s1 s2 s3 _ _ _ (sftrp .s2 .s3) = sftrp s1 s3
+
+  -- s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ a3) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp (inj₂ b1) (inj₁ a2)) (sft₁ daa2) with sfromto→⊕ (inj₁ (inj₁ da2)) _ _ (sft₁ daa2)
+  -- s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ .(a2 ⊕ da2)) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp (inj₂ b1) (inj₁ a2)) (sft₁ daa2) | refl = sftrp (inj₂ b1) (inj₁ (a2 ⊕ da2))
+  -- s⊚-fromto .(inj₁ a1) .(inj₂ b2) (inj₂ b3) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp (inj₁ a1) (inj₂ b2)) (sft₂ dbb2) with sfromto→⊕ (inj₁ (inj₂ db2)) _ _ (sft₂ dbb2)
+  -- s⊚-fromto .(inj₁ a1) .(inj₂ b2) (inj₂ .(b2 ⊕ db2)) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp (inj₁ a1) (inj₂ b2)) (sft₂ dbb2) | refl = sftrp (inj₁ a1) (inj₂ (b2 ⊕ db2))
 
   instance
     sumCS : ChangeStructure (A ⊎ B)

--- a/Thesis/Changes.agda
+++ b/Thesis/Changes.agda
@@ -271,17 +271,53 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
   s⊝-fromto (inj₁ a1) (inj₂ b2) = sftrp₁ a1 b2
   s⊝-fromto (inj₂ b1) (inj₁ a2) = sftrp₂ b1 a2
   s⊝-fromto (inj₂ b1) (inj₂ b2) = sft₂ (⊝-fromto b1 b2)
+  _s⊚2[_]_ : SumChange2 → A ⊎ B → SumChange2 → SumChange2
+  ch₁ da1 s⊚2[ inj₁ a ] ch₁ da2 = ch₁ (da1 ⊚[ a ] da2)
+  ch₁ da1 s⊚2[ inj₂ b ] ch₁ da2 = {!!}
+  ch₂ db s⊚2[ s ] ch₁ da = {!!}
+  rp (inj₁ a2) s⊚2[ s ] ch₁ da2 = rp (inj₁ (a2 ⊕ da2))
+  rp (inj₂ y) s⊚2[ s ] ch₁ da2 = {!!}
+  ch₁ da s⊚2[ s ] ch₂ db = {!!}
+  ch₂ db1 s⊚2[ inj₁ a ] ch₂ db2 = ch₂ {!!}
+  ch₂ db1 s⊚2[ inj₂ b ] ch₂ db2 = ch₂ (db1 ⊚[ b ] db2)
+  rp (inj₁ a2) s⊚2[ s ] ch₂ db2 = {!!}
+  rp (inj₂ b2) s⊚2[ s ] ch₂ db2 = rp (inj₂ (b2 ⊕ db2))
+  ch₁ da s⊚2[ s ] rp s₁ = rp s₁
+  ch₂ db s⊚2[ s ] rp s₁ = rp s₁
+  rp s2 s⊚2[ s1 ] rp s3 = rp s3
+
+  _s⊚[_]_ : SumChange → A ⊎ B → SumChange → SumChange
+  ds1 s⊚[ s ] ds2 = convert₁ (convert ds1 s⊚2[ s ] convert ds2)
+
+  s⊚-fromto : (s1 s2 s3 : A ⊎ B) (ds1 ds2 : SumChange) →
+      sch ds1 from s1 to s2 →
+      sch ds2 from s2 to s3 → sch ds1 s⊚[ s1 ] ds2 from s1 to s3
+  s⊚-fromto (inj₁ a1) (inj₁ a2) (inj₁ a3) (inj₁ (inj₁ da1)) (inj₁ (inj₁ da2)) (sft₁ daa1) (sft₁ daa2) = sft₁ (⊚-fromto a1 a2 a3 _ _ daa1 daa2)
+  s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ a3) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) with sfromto→⊕ (inj₁ (inj₁ da2)) _ _ (sft₁ daa2)
+  s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ .(a2 ⊕ da2)) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) | refl = sftrp₂ b1 (a2 ⊕ da2)
+  s⊚-fromto (inj₂ b1) (inj₂ b2) (inj₂ b3) (inj₁ (inj₂ db1)) (inj₁ (inj₂ db2)) (sft₂ dbb1) (sft₂ dbb2) = sft₂ (⊚-fromto b1 b2 b3 _ _ dbb1 dbb2)
+  s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ _) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) with sfromto→⊕ (inj₁ (inj₂ db2)) _ _ (sft₂ dbb2)
+  s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ (b2 ⊕ db2)) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) | refl = sftrp₁ a1 (b2 ⊕ db2)
+  s⊚-fromto (inj₁ a1) .(inj₁ a2) .(inj₂ b2) .(inj₁ (inj₁ _)) .(inj₂ (inj₂ b2)) (sft₁ daa) (sftrp₁ a2 b2) = sftrp₁ a1 b2
+  s⊚-fromto .(inj₂ b1) .(inj₁ a1) .(inj₂ b2) .(inj₂ (inj₁ a1)) .(inj₂ (inj₂ b2)) (sftrp₂ b1 .a1) (sftrp₁ a1 b2) = {!!}
+  s⊚-fromto .(inj₂ _) .(inj₂ b2) .(inj₁ a2) .(inj₁ (inj₂ _)) .(inj₂ (inj₁ a2)) (sft₂ dbb2) (sftrp₂ b2 a2) = sftrp₂ _ _
+  s⊚-fromto .(inj₁ a1) .(inj₂ b1) .(inj₁ a2) .(inj₂ (inj₂ b1)) .(inj₂ (inj₁ a2)) (sftrp₁ a1 .b1) (sftrp₂ b1 a2) = {!!}
+
   instance
     sumCS : ChangeStructure (A ⊎ B)
   sumCS = record
     { Ch = SumChange
     ; ch_from_to_ = sch_from_to_
-    ; isCompChangeStructure = IsChangeStructure→IsCompChangeStructure (record
+    ; isCompChangeStructure = record
+      { isChangeStructure = record
       { _⊕_ = _s⊕_
       ; fromto→⊕ = sfromto→⊕
       ; _⊝_ = _s⊝_
       ; ⊝-fromto = s⊝-fromto
-      })
+      }
+      ; _⊚[_]_ = _s⊚[_]_
+      ; ⊚-fromto = s⊚-fromto
+      }
     }
 
 instance

--- a/Thesis/Changes.agda
+++ b/Thesis/Changes.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --allow-unsolved-metas #-}
 module Thesis.Changes where
 
 open import Data.Product
@@ -229,11 +230,11 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
 
   private
     _s⊕2_ : A ⊎ B → SumChange2 → A ⊎ B
+    _s⊕2_ s (rp s₁) = s₁
     _s⊕2_ (inj₁ a) (ch₁ da) = inj₁ (a ⊕ da)
     _s⊕2_ (inj₂ b) (ch₂ db) = inj₂ (b ⊕ db)
     _s⊕2_ (inj₂ b) (ch₁ da) = inj₂ b -- invalid
     _s⊕2_ (inj₁ a) (ch₂ db) = inj₁ a -- invalid
-    _s⊕2_ s (rp s₁) = s₁
 
     _s⊕_ : A ⊎ B → SumChange → A ⊎ B
     s s⊕ ds = s s⊕2 (convert ds)
@@ -252,6 +253,7 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
     sft₂ : ∀ {db b1 b2} (dbb : ch db from b1 to b2) → sch (convert₁ (ch₂ db)) from (inj₂ b1) to (inj₂ b2)
     sftrp₁ : ∀ a1 b2 → sch (convert₁ (rp (inj₂ b2))) from (inj₁ a1) to (inj₂ b2)
     sftrp₂ : ∀ b1 a2 → sch (convert₁ (rp (inj₁ a2))) from (inj₂ b1) to (inj₁ a2)
+    sftrp : ∀ s1 s2 → sch (convert₁ (rp s2)) from s1 to s2
 
   sfromto→⊕2 : (ds : SumChange2) (s1 s2 : A ⊎ B) →
     sch convert₁ ds from s1 to s2 → s1 s⊕2 ds ≡ s2
@@ -259,6 +261,7 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
   sfromto→⊕2 (ch₂ db) (inj₂ b1) (inj₂ b2) (sft₂ dbb) = cong inj₂ (fromto→⊕ _ _ _ dbb)
   sfromto→⊕2 (rp .(inj₂ y)) (inj₁ x) (inj₂ y) (sftrp₁ .x .y) = refl
   sfromto→⊕2 (rp .(inj₁ x)) (inj₂ y) (inj₁ x) (sftrp₂ .y .x) = refl
+  sfromto→⊕2 (rp .s2) .s1 .s2 (sftrp s1 s2) = refl
 
   sfromto→⊕ : (ds : SumChange) (s1 s2 : A ⊎ B) →
     sch ds from s1 to s2 → s1 s⊕ ds ≡ s2
@@ -271,20 +274,22 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
   s⊝-fromto (inj₁ a1) (inj₂ b2) = sftrp₁ a1 b2
   s⊝-fromto (inj₂ b1) (inj₁ a2) = sftrp₂ b1 a2
   s⊝-fromto (inj₂ b1) (inj₂ b2) = sft₂ (⊝-fromto b1 b2)
+
+  -- TODO: drop all indexes prefixed with _
   _s⊚2[_]_ : SumChange2 → A ⊎ B → SumChange2 → SumChange2
-  ch₁ da1 s⊚2[ inj₁ a ] ch₁ da2 = ch₁ (da1 ⊚[ a ] da2)
-  ch₁ da1 s⊚2[ inj₂ b ] ch₁ da2 = {!!}
-  ch₂ db s⊚2[ s ] ch₁ da = {!!}
-  rp (inj₁ a2) s⊚2[ s ] ch₁ da2 = rp (inj₁ (a2 ⊕ da2))
-  rp (inj₂ y) s⊚2[ s ] ch₁ da2 = {!!}
-  ch₁ da s⊚2[ s ] ch₂ db = {!!}
-  ch₂ db1 s⊚2[ inj₁ a ] ch₂ db2 = ch₂ {!!}
-  ch₂ db1 s⊚2[ inj₂ b ] ch₂ db2 = ch₂ (db1 ⊚[ b ] db2)
-  rp (inj₁ a2) s⊚2[ s ] ch₂ db2 = {!!}
-  rp (inj₂ b2) s⊚2[ s ] ch₂ db2 = rp (inj₂ (b2 ⊕ db2))
-  ch₁ da s⊚2[ s ] rp s₁ = rp s₁
-  ch₂ db s⊚2[ s ] rp s₁ = rp s₁
-  rp s2 s⊚2[ s1 ] rp s3 = rp s3
+  ch₁ da1 s⊚2[ inj₁ _a ] ch₁ da2 = ch₁ (da1 ⊚[ _a ] da2)
+  ch₁ da1 s⊚2[ inj₂ _b ] ch₁ da2 = {!!}
+  ch₂ db s⊚2[ _s ] ch₁ da = {!!}
+  rp (inj₁ a2) s⊚2[ _s ] ch₁ da2 = rp (inj₁ (a2 ⊕ da2))
+  rp (inj₂ y) s⊚2[ _s ] ch₁ da2 = {!!}
+  ch₁ da s⊚2[ _s ] ch₂ db = {!!}
+  ch₂ db1 s⊚2[ inj₁ _a ] ch₂ db2 = ch₂ {!!}
+  ch₂ db1 s⊚2[ inj₂ _b ] ch₂ db2 = ch₂ (db1 ⊚[ _b ] db2)
+  rp (inj₁ a2) s⊚2[ _s ] ch₂ db2 = {!!}
+  rp (inj₂ b2) s⊚2[ _s ] ch₂ db2 = rp (inj₂ (b2 ⊕ db2))
+  ch₁ da s⊚2[ _s ] rp s₁ = rp s₁
+  ch₂ db s⊚2[ _s ] rp s₁ = rp s₁
+  rp s2 s⊚2[ _s1 ] rp s3 = rp s3
 
   _s⊚[_]_ : SumChange → A ⊎ B → SumChange → SumChange
   ds1 s⊚[ s ] ds2 = convert₁ (convert ds1 s⊚2[ s ] convert ds2)
@@ -292,16 +297,18 @@ module _ {A B : Set} {{CA : ChangeStructure A}} {{CB : ChangeStructure B}} where
   s⊚-fromto : (s1 s2 s3 : A ⊎ B) (ds1 ds2 : SumChange) →
       sch ds1 from s1 to s2 →
       sch ds2 from s2 to s3 → sch ds1 s⊚[ s1 ] ds2 from s1 to s3
-  s⊚-fromto (inj₁ a1) (inj₁ a2) (inj₁ a3) (inj₁ (inj₁ da1)) (inj₁ (inj₁ da2)) (sft₁ daa1) (sft₁ daa2) = sft₁ (⊚-fromto a1 a2 a3 _ _ daa1 daa2)
-  s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ a3) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) with sfromto→⊕ (inj₁ (inj₁ da2)) _ _ (sft₁ daa2)
-  s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ .(a2 ⊕ da2)) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) | refl = sftrp₂ b1 (a2 ⊕ da2)
-  s⊚-fromto (inj₂ b1) (inj₂ b2) (inj₂ b3) (inj₁ (inj₂ db1)) (inj₁ (inj₂ db2)) (sft₂ dbb1) (sft₂ dbb2) = sft₂ (⊚-fromto b1 b2 b3 _ _ dbb1 dbb2)
-  s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ _) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) with sfromto→⊕ (inj₁ (inj₂ db2)) _ _ (sft₂ dbb2)
-  s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ (b2 ⊕ db2)) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) | refl = sftrp₁ a1 (b2 ⊕ db2)
-  s⊚-fromto (inj₁ a1) .(inj₁ a2) .(inj₂ b2) .(inj₁ (inj₁ _)) .(inj₂ (inj₂ b2)) (sft₁ daa) (sftrp₁ a2 b2) = sftrp₁ a1 b2
-  s⊚-fromto .(inj₂ b1) .(inj₁ a1) .(inj₂ b2) .(inj₂ (inj₁ a1)) .(inj₂ (inj₂ b2)) (sftrp₂ b1 .a1) (sftrp₁ a1 b2) = {!!}
-  s⊚-fromto .(inj₂ _) .(inj₂ b2) .(inj₁ a2) .(inj₁ (inj₂ _)) .(inj₂ (inj₁ a2)) (sft₂ dbb2) (sftrp₂ b2 a2) = sftrp₂ _ _
-  s⊚-fromto .(inj₁ a1) .(inj₂ b1) .(inj₁ a2) .(inj₂ (inj₂ b1)) .(inj₂ (inj₁ a2)) (sftrp₁ a1 .b1) (sftrp₂ b1 a2) = {!!}
+  s⊚-fromto = {!!}
+
+  -- s⊚-fromto (inj₁ a1) (inj₁ a2) (inj₁ a3) (inj₁ (inj₁ da1)) (inj₁ (inj₁ da2)) (sft₁ daa1) (sft₁ daa2) = sft₁ (⊚-fromto a1 a2 a3 _ _ daa1 daa2)
+  -- s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ a3) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) with sfromto→⊕ (inj₁ (inj₁ da2)) _ _ (sft₁ daa2)
+  -- s⊚-fromto .(inj₂ b1) .(inj₁ a2) (inj₁ .(a2 ⊕ da2)) .(inj₂ (inj₁ a2)) (inj₁ (inj₁ da2)) (sftrp₂ b1 a2) (sft₁ daa2) | refl = sftrp₂ b1 (a2 ⊕ da2)
+  -- s⊚-fromto (inj₂ b1) (inj₂ b2) (inj₂ b3) (inj₁ (inj₂ db1)) (inj₁ (inj₂ db2)) (sft₂ dbb1) (sft₂ dbb2) = sft₂ (⊚-fromto b1 b2 b3 _ _ dbb1 dbb2)
+  -- s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ _) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) with sfromto→⊕ (inj₁ (inj₂ db2)) _ _ (sft₂ dbb2)
+  -- s⊚-fromto .(inj₁ a1) .(inj₂ b2) .(inj₂ (b2 ⊕ db2)) .(inj₂ (inj₂ b2)) (inj₁ (inj₂ db2)) (sftrp₁ a1 b2) (sft₂ dbb2) | refl = sftrp₁ a1 (b2 ⊕ db2)
+  -- s⊚-fromto (inj₁ a1) .(inj₁ a2) .(inj₂ b2) .(inj₁ (inj₁ _)) .(inj₂ (inj₂ b2)) (sft₁ daa) (sftrp₁ a2 b2) = sftrp₁ a1 b2
+  -- s⊚-fromto .(inj₂ b1) .(inj₁ a1) .(inj₂ b2) .(inj₂ (inj₁ a1)) .(inj₂ (inj₂ b2)) (sftrp₂ b1 .a1) (sftrp₁ a1 b2) = {!!}
+  -- s⊚-fromto .(inj₂ _) .(inj₂ b2) .(inj₁ a2) .(inj₁ (inj₂ _)) .(inj₂ (inj₁ a2)) (sft₂ dbb2) (sftrp₂ b2 a2) = sftrp₂ _ _
+  -- s⊚-fromto .(inj₁ a1) .(inj₂ b1) .(inj₁ a2) .(inj₂ (inj₂ b1)) .(inj₂ (inj₁ a2)) (sftrp₁ a1 .b1) (sftrp₂ b1 a2) = {!!}
 
   instance
     sumCS : ChangeStructure (A ⊎ B)

--- a/Thesis/Derive.agda
+++ b/Thesis/Derive.agda
@@ -153,3 +153,24 @@ module _ {t1 t2 t3 : Type}
       ≡
         f a2 ⊕ df a2 (nil a2) ⊝ g b1
     changeMatchSem-lem2 b1 a2 rewrite ominusτ-equiv-ext t1 Γ′′ | oplusτ-equiv-ext t3 Γ′ | ominusτ-equiv-ext t3 Γ = refl
+  module _ where
+    private
+      Γ′ Γ′′ : Context
+      Γ′ = t1 • (t1 ⇒ Δt t1 ⇒ Δt t3) • (t1 ⇒ t3) • Γ
+      Γ′′ = t1 • Γ′
+    changeMatchSem-lem3 :
+      ∀ a1 a2 →
+        ⟦ match ⟧ΔConst (inj₁ a1) (inj₂ (inj₁ a2)) f df g dg ≡
+        f a2 ⊕ df a2 (nil a2) ⊝ f a1
+    changeMatchSem-lem3 a1 a2 rewrite ominusτ-equiv-ext t1 Γ′′ | oplusτ-equiv-ext t3 Γ′ | ominusτ-equiv-ext t3 Γ = refl
+  module _ where
+    private
+      Γ′ Γ′′ : Context
+      Γ′ = t2 • (t2 ⇒ Δt t2 ⇒ Δt t3) • (t2 ⇒ t3) • Γ
+      Γ′′ = t2 • Γ′
+    changeMatchSem-lem4 :
+      ∀ b1 b2 →
+        ⟦ match ⟧ΔConst (inj₂ b1) (inj₂ (inj₂ b2)) f df g dg
+      ≡
+        g b2 ⊕ dg b2 (nil b2) ⊝ g b1
+    changeMatchSem-lem4 b1 b2 rewrite ominusτ-equiv-ext t2 Γ′′ | oplusτ-equiv-ext t3 Γ′ | ominusτ-equiv-ext t3 Γ = refl

--- a/Thesis/DeriveCorrect.agda
+++ b/Thesis/DeriveCorrect.agda
@@ -22,14 +22,6 @@ fromtoDeriveConst linj da a1 a2 daa = sft₁ daa
 fromtoDeriveConst rinj db b1 b2 dbb = sft₂ dbb
 fromtoDeriveConst match .(inj₁ (inj₁ _)) .(inj₁ _) .(inj₁ _) (sft₁ daa) df f1 f2 dff dg g1 g2 dgg = dff _ _ _ daa
 fromtoDeriveConst match .(inj₁ (inj₂ _)) .(inj₂ _) .(inj₂ _) (sft₂ dbb) df f1 f2 dff dg g1 g2 dgg = dgg _ _ _ dbb
-fromtoDeriveConst match .(inj₂ (inj₂ b2)) .(inj₁ a1) .(inj₂ b2) (sftrp₁ a1 b2) df f1 f2 dff dg g1 g2 dgg
- rewrite changeMatchSem-lem1 f1 df g1 dg a1 b2
- | sym (fromto→⊕ dg g1 g2 dgg)
- = ⊝-fromto (f1 a1) ((g1 ⊕ dg) b2)
-fromtoDeriveConst match .(inj₂ (inj₁ a2)) .(inj₂ b1) .(inj₁ a2) (sftrp₂ b1 a2) df f1 f2 dff dg g1 g2 dgg
-  rewrite changeMatchSem-lem2 f1 df g1 dg b1 a2
-  | sym (fromto→⊕ df f1 f2 dff)
-   = ⊝-fromto (g1 b1) ((f1 ⊕ df) a2)
 fromtoDeriveConst match .(inj₂ (inj₂ b2)) .(inj₁ a1) .(inj₂ b2) (sftrp (inj₁ a1) (inj₂ b2)) df f1 f2 dff dg g1 g2 dgg
  rewrite changeMatchSem-lem1 f1 df g1 dg a1 b2
  | sym (fromto→⊕ dg g1 g2 dgg)

--- a/Thesis/DeriveCorrect.agda
+++ b/Thesis/DeriveCorrect.agda
@@ -24,11 +24,28 @@ fromtoDeriveConst match .(inj₁ (inj₁ _)) .(inj₁ _) .(inj₁ _) (sft₁ daa
 fromtoDeriveConst match .(inj₁ (inj₂ _)) .(inj₂ _) .(inj₂ _) (sft₂ dbb) df f1 f2 dff dg g1 g2 dgg = dgg _ _ _ dbb
 fromtoDeriveConst match .(inj₂ (inj₂ b2)) .(inj₁ a1) .(inj₂ b2) (sftrp₁ a1 b2) df f1 f2 dff dg g1 g2 dgg
  rewrite changeMatchSem-lem1 f1 df g1 dg a1 b2
- | sym (fromto→⊕ dg g1 g2 dgg) = ⊝-fromto (f1 a1) ((g1 ⊕ dg) b2)
+ | sym (fromto→⊕ dg g1 g2 dgg)
+ = ⊝-fromto (f1 a1) ((g1 ⊕ dg) b2)
 fromtoDeriveConst match .(inj₂ (inj₁ a2)) .(inj₂ b1) .(inj₁ a2) (sftrp₂ b1 a2) df f1 f2 dff dg g1 g2 dgg
   rewrite changeMatchSem-lem2 f1 df g1 dg b1 a2
   | sym (fromto→⊕ df f1 f2 dff)
    = ⊝-fromto (g1 b1) ((f1 ⊕ df) a2)
+fromtoDeriveConst match .(inj₂ (inj₂ b2)) .(inj₁ a1) .(inj₂ b2) (sftrp (inj₁ a1) (inj₂ b2)) df f1 f2 dff dg g1 g2 dgg
+ rewrite changeMatchSem-lem1 f1 df g1 dg a1 b2
+ | sym (fromto→⊕ dg g1 g2 dgg)
+ = ⊝-fromto (f1 a1) ((g1 ⊕ dg) b2)
+fromtoDeriveConst match .(inj₂ (inj₁ a2)) .(inj₂ b1) .(inj₁ a2) (sftrp (inj₂ b1) (inj₁ a2)) df f1 f2 dff dg g1 g2 dgg
+  rewrite changeMatchSem-lem2 f1 df g1 dg b1 a2
+  | sym (fromto→⊕ df f1 f2 dff)
+  = ⊝-fromto (g1 b1) ((f1 ⊕ df) a2)
+fromtoDeriveConst match .(inj₂ (inj₁ a2)) .(inj₁ a1) .(inj₁ a2) (sftrp (inj₁ a1) (inj₁ a2)) df f1 f2 dff dg g1 g2 dgg
+  rewrite changeMatchSem-lem3 f1 df g1 dg a1 a2
+  | sym (fromto→⊕ df f1 f2 dff)
+  = ⊝-fromto (f1 a1) ((f1 ⊕ df) a2)
+fromtoDeriveConst match .(inj₂ (inj₂ b2)) .(inj₂ b1) .(inj₂ b2) (sftrp (inj₂ b1) (inj₂ b2)) df f1 f2 dff dg g1 g2 dgg
+  rewrite changeMatchSem-lem4 f1 df g1 dg b1 b2
+ | sym (fromto→⊕ dg g1 g2 dgg)
+  = ⊝-fromto (g1 b1) ((g1 ⊕ dg) b2)
 
 fromtoDeriveVar : ∀ {Γ τ} → (x : Var Γ τ) →
   ∀ {dρ ρ1 ρ2} → [ Γ ]Γ dρ from ρ1 to ρ2 →

--- a/Thesis/IntChanges.agda
+++ b/Thesis/IntChanges.agda
@@ -20,7 +20,7 @@ intCS = record
       ; _⊝_ = _-_
       ; ⊝-fromto = λ a b → n+[m-n]=m {a} {b}
       }
-    ; _⊚[_]_ = λ da1 a da2 → da1 + da2
+    ; _⊚_ = λ da1 da2 → da1 + da2
     ; ⊚-fromto = i⊚-fromto
     }
   }

--- a/Thesis/LangChanges.agda
+++ b/Thesis/LangChanges.agda
@@ -83,13 +83,13 @@ module _ where
   e⊝-fromto ∅ ∅ = v∅
   e⊝-fromto (v1 • ρ1) (v2 • ρ2) = ⊝-fromto v1 v2 v• e⊝-fromto ρ1 ρ2
 
-  _e⊚[_]_ : ∀ {Γ} → ChΓ Γ → ⟦ Γ ⟧Context → ChΓ Γ → ChΓ Γ
-  _e⊚[_]_ {∅} ∅ ∅ ∅ = ∅
-  _e⊚[_]_ {τ • Γ} (dv1 • _ • dρ1) (v1 • ρ1) (dv2 • _ • dρ2) = (dv1 ⊚[ v1 ] dv2) • v1 • (dρ1 e⊚[ ρ1 ] dρ2)
+  _e⊚_ : ∀ {Γ} → ChΓ Γ → ChΓ Γ → ChΓ Γ
+  _e⊚_ {∅} ∅ ∅ = ∅
+  _e⊚_ {τ • Γ} (dv1 • v1 • dρ1) (dv2 • _ • dρ2) = dv1 ⊚[ ⟦ τ ⟧Type ] dv2 • v1 • dρ1 e⊚ dρ2
 
   e⊚-fromto : ∀ Γ → (ρ1 ρ2 ρ3 : ⟦ Γ ⟧Context) (dρ1 dρ2 : ChΓ Γ) →
     [ Γ ]Γ dρ1 from ρ1 to ρ2 →
-    [ Γ ]Γ dρ2 from ρ2 to ρ3 → [ Γ ]Γ (dρ1 e⊚[ ρ1 ] dρ2) from ρ1 to ρ3
+    [ Γ ]Γ dρ2 from ρ2 to ρ3 → [ Γ ]Γ (dρ1 e⊚ dρ2) from ρ1 to ρ3
   e⊚-fromto ∅ ∅ ∅ ∅ ∅ ∅ v∅ v∅ = v∅
   e⊚-fromto (τ • Γ) (v1 • ρ1) (v2 • ρ2) (v3 • ρ3)
     (dv1 • (.v1 • dρ1)) (dv2 • (.v2 • dρ2))
@@ -105,7 +105,7 @@ module _ where
       ; _⊝_ = _e⊝_
       ; ⊝-fromto = e⊝-fromto
       }
-    ; _⊚[_]_ = _e⊚[_]_
+    ; _⊚_ = _e⊚_
     ; ⊚-fromto = e⊚-fromto Γ
     }
 


### PR DESCRIPTION
A base value is required to define change composition as a derived operation. Which nobody has asked us about, so stop doing that.

This requires defining type-specific change composition for all types, including sums, so do that.